### PR TITLE
2: Add basic project layout with linters

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,39 @@
+[flake8]
+
+filename = ./src/*
+max-line-length = 120
+
+enable-extensions =
+    TC,  # flake8-type-checking: common error codes
+    TC1  # flake8-type-checking: TC100 and TC101 manage forward references by taking advantage of
+         # postponed evaluation of annotations
+
+ignore =
+    ANN101,  # Missing type annotation for self in method
+    ANN102,  # Missing type annotation for cls in class method
+    E902,  # TokenError: EOF in multi-line statement
+    S101,  # Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+    W503,  # Line break occurred before a binary operator.
+
+# NEXT WILL BE LISTED SOME OPTIONS USED BY PLUGINS
+# PLEASE KEEP THIS LIST SORTED BY PLUGIN NAMES ALPHABETICALLY
+
+# darglint =============================================================================================================
+# The docstring style type
+docstring_style = sphinx
+# Strictness determines how lax darglint will be when checking docstrings.
+# short: One-line descriptions are acceptable; anything more and the docstring will be fully checked
+strictness = short
+
+# flake8-import-order ==================================================================================================
+application-import-names = src
+# Controls what style the plugin follows.
+import-order-style = smarkets
+
+# flake8-quotes ========================================================================================================
+# Set up allowed type of quotes
+inline-quotes = double
+
+# flake8-spellcheck ====================================================================================================
+# Disable spellcheck error for words listed in this file
+whitelist = whitelist.txt

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+
+files = src
+
+strict = True

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,99 @@
+[MAIN]
+
+load-plugins=
+    pylint.extensions.bad_builtin,  # It can be used for finding prohibited used builtins, such as map or filter, for which other alternatives exists.
+    pylint.extensions.broad_try_clause,  # Maximum number of statements allowed in a try clause.
+    pylint.extensions.check_elif,  # Used when an else statement is immediately followed by an if statement and does not contain statements that would be unrelated to it.
+    pylint.extensions.code_style,  # Checkers that can improve code consistency. As such they don't necessarily provide a performance benefit and are often times opinionated.
+    pylint.extensions.comparetozero,  # "%s" can be simplified to "%s" as 0 is falsey Used when Pylint detects comparison to a 0 constant.
+    pylint.extensions.comparison_placement,  # Used when the constant is placed on the left side of a comparison. It is usually clearer in intent to place it in the right hand side of the comparison.
+    pylint.extensions.confusing_elif,  # Used when an elif statement follows right after an indented block which itself ends with if or elif. It may not be ovious if the elif statement was willingly or mistakenly unindented.
+    pylint.extensions.consider_ternary_expression,  # Multiple assign statements spread across if/else blocks can be rewritten with a single assignment and ternary expression.
+    pylint.extensions.docparams,  # If you document the parameters of your functions, methods and constructors and their types systematically in your code this optional component might be useful for you.
+    pylint.extensions.docstyle,  # Checks bad docstring quotes and first line emptiness.
+    pylint.extensions.empty_comment,  # Used when a # symbol appears on a line not followed by an actual comment.
+    pylint.extensions.emptystring,  # Used when Pylint detects comparison to an empty string constant.
+    pylint.extensions.eq_without_hash,  # Used when a class implements __eq__ but not __hash__.
+    pylint.extensions.for_any_all,  # A for loop that checks for a condition and return a bool can be replaced with any or all.
+    pylint.extensions.mccabe,  # You can now use this plugin for finding complexity issues in your code base.
+    pylint.extensions.no_self_use,  # Used when a method doesn't use its bound instance, and so could be written as a function.
+    pylint.extensions.overlapping_exceptions,  # Used when exceptions in handler overlap or are identical.
+    pylint.extensions.private_import,  # Used when a private module or object prefixed with _ is imported.
+    pylint.extensions.redefined_loop_name,  # Used when a loop variable is overwritten in the loop body.
+    pylint.extensions.redefined_variable_type,  # Used when the type of a variable changes inside a method or a function.
+    pylint.extensions.set_membership,  # Membership tests are more efficient when performed on a lookup optimized datatype like sets.
+    pylint.extensions.typing,  # Find issue specifically related to type annotations
+    pylint.extensions.while_used,  # While loops can often be rewritten as bounded for loops.
+
+
+[BASIC]
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=
+    bar,
+    baz,
+    f,
+    foo,
+    r,
+    u,
+    x,
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=
+    i,
+    j,
+    k,
+    _,
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=yes
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=120
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=new
+
+
+[MESSAGES CONTROL]
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+    useless-suppression,  # Reported when a message is explicitly disabled for a line or a block of code, but never triggered.
+
+
+[SPELLING]
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=
+    mypy:,
+    noqa,
+    noqa:,
+    type,
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+
+[STRING]
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=yes
+
+
+[VARIABLES]
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=no

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Forum123 backend
+
+## Development setup
+
+__This project requires Python 3.10.__
+
+
+
+### First time setup
+
+If this is your first run of this project you need to create and activate python virtual environment.
+You can do it in the way you are more familiar with but here is an example of how it can be done:
+
+1. Go to the project root directory.
+2. Create virtual environment: `python3.10 -m venv .venv/forum123`
+3. Activate virtual environment: `source .venv/forum123/bin/activate`
+4. Install dependencies: `pip install -r requirements.txt -r requirements-dev.txt`
+
+_Note_: If you've created a virtual environment inside project directory
+and don't want it to be tracked by git, please do not add it to `.gitignore` file.
+There are other ways to do it correctly - choose any of these or find your own:
+
+- Add virtual environment directory to `.git/info/exclude` file of this repository.
+- Add local `.gitignore` file to the directory of your virtual env and put `*` inside this file.
+
+
+
+### Run linters
+
+1. Go to the project root directory.
+2. Activate python virtual environment.
+3. Run `mypy`
+4. Run `flake8`
+5. Run `pylint src`
+
+Linters order above is the preffered way to run and fix them one by one.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,30 @@
+# Development dependencies. Please keep this list in alphabetical order.
+
+darglint==1.8.1  # Checks whether a docstring's description matches the actual function/method implementation
+dlint==0.12.0  # Tool for encouraging best coding practices and helping ensure Python code is secure.
+flake8-absolute-import==1.0  # Plugin to require absolute imports.
+flake8-annotations==2.7.0  # Plugin for flake8 to check for presence of type annotations in function definitions.
+flake8-annotations-complexity==0.0.6  # Plugin to validate annotations complexity.
+flake8-bandit==2.0.0  # Automated security testing using bandit.
+flake8-bugbear==21.9.2  # Finding likely bugs and design problems in your program
+flake8-builtins==1.5.3  # Check for python builtins being used as variables or parameters.
+flake8-codes==0.1.1  # CLI tool to introspect flake8 plugins and their codes.
+flake8-cognitive-complexity==0.1.0  # Extension for flake8 that validates cognitive functions complexity.
+flake8-commas==2.1.0  # Enforcing trailing commas in python.
+flake8-comprehensions==3.7.0  # Helps you write better list/set/dict comprehensions.
+flake8-docstrings==1.6.0  # Include checks provided by pep257
+flake8-eradicate==1.1.0  # Plugin to find commented out or dead code.
+flake8-executable==2.1.1  # Plugin for checking executable permissions and shebangs.
+flake8-functions==0.0.6  # Plugin for validation of function parameters (length, complexity, etc).
+flake8-import-order==0.18.1  # Include checks import order against various Python Style Guides.
+flake8-mutable==1.2.0  # Extension for mutable default arguments.
+flake8-print==4.0.0  # Check for print statements in python files.
+flake8-quotes==3.3.0  # Extension for checking quotes in python.
+flake8-return==1.1.3  # Plugin that checks return values.
+flake8-rst-docstrings==0.2.3  # Validate Python docstrings as reStructuredText (RST)
+flake8-simplify==0.14.2  # Plugin that helps you to simplify code.
+flake8-spellcheck==0.24.0  # Spellcheck variables, classnames, comments, docstrings etc.
+flake8-type-checking==1.0.3  # Plugin for managing type-checking imports & forward references.
+flake8==3.9.2
+mypy==0.991
+pylint==2.15.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# Project dependencies. Please keep this list in alphabetical order.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Main package for source code."""

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,0 +1,2 @@
+# This is a whitelist of allowed words for flake8-spellcheck plugin.
+# IMPORTANT: please keep this list alphabetically sorted by whitelisted words


### PR DESCRIPTION
In the scope of this task we need to add and configure following linters:
    - `mypy`
    - `flake8`
    - `pylint`

Since we're going to use `flake8` and `pylint` together, there may be conflicts between their configurations. Now it's difficult to track all options and resolve conflicts between them, so we decided to fix them ad-hoc in cases where it will be needed.

Some files like `requirements.txt` and `whitelist.txt` are left blank for now, but we hope they're going to be filled soon, so they shouldn't be considered as redundant. If these files keep to be blank for a long time - feel free to remove them.

GitHub issues: closes #2.