### PR TITLE
5 add registration page

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,11 @@
 [flake8]
 
 filename = ./src/*
+
+exclude =
+    *.html,
+    __pycache__,
+
 max-line-length = 120
 
 enable-extensions =

--- a/.flaskenv
+++ b/.flaskenv
@@ -1,0 +1,1 @@
+FLASK_APP=src 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -3,3 +3,12 @@
 files = src
 
 strict = True
+
+[mypy-flask_wtf]
+ignore_missing_imports = True
+
+[mypy-wtforms.validators]
+ignore_missing_imports = True
+
+[mypy-wtforms]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 # Project dependencies. Please keep this list in alphabetical order.
 
 flask==2.2.2
+flask-WTF==1.0.1
+python-dotenv==0.21.0
+wtforms==3.0.1

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,7 +3,8 @@
 from flask import Flask
 
 from src import routes
-
+from src.config import Config
 
 app = Flask(__name__)
 app.register_blueprint(routes.bp)
+app.config.from_object(Config)

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,9 @@
+"""forum123's configuration module."""
+
+import os
+
+
+class Config():  # pylint: disable=too-few-public-methods
+    """Configuration class."""
+
+    SECRET_KEY = os.environ.get("SECRET_KEY", "bob")

--- a/src/forms.py
+++ b/src/forms.py
@@ -1,0 +1,13 @@
+"""forum123's forms module."""
+
+from flask_wtf import FlaskForm
+from wtforms import PasswordField, StringField, SubmitField
+from wtforms.validators import DataRequired
+
+
+class RegistrationForm(FlaskForm):  # type: ignore
+    """A class for a regitration form."""
+
+    username = StringField("Username", validators=[DataRequired()])
+    password = PasswordField("Password", validators=[DataRequired()])
+    submit = SubmitField("Sign Up")

--- a/src/routes.py
+++ b/src/routes.py
@@ -1,6 +1,9 @@
 """forum123's route module."""
 
 from flask import Blueprint
+from flask import render_template
+
+from src.forms import RegistrationForm
 
 
 bp = Blueprint("routes", __name__)
@@ -8,6 +11,13 @@ bp = Blueprint("routes", __name__)
 
 @bp.route("/")
 @bp.route("/index")
-def index() -> str:  # pylint: disable=unused-variable
+def index() -> str:
     """Use this view function to check whether Flask is installed properly."""
     return "Hello, wordl!"
+
+
+@bp.route("/registration")
+def registration() -> str:
+    """Handle user's registration form."""
+    form = RegistrationForm()
+    return render_template("registration.html", form=form)

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+      <title>forum123</title>
+    </head>
+    <body>
+      <div>
+        forum123
+        <a href="{{ url_for('routes.registration') }}">Sign Up</a>
+      </div>
+      {% block content %}{% endblock %}
+    </body>
+</html>

--- a/src/templates/registration.html
+++ b/src/templates/registration.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>Register</h1>
+    <form method="POST" action="" novalidate>
+        {{ form.hidden_tag() }}
+        <p>
+            {{ form.username.label }}<br>
+            {{ form.username(size=32) }}
+        </p>
+        <p>
+            {{ form.password.label }}<br>
+            {{ form.password(size=32) }}
+        </p>
+        <p>{{ form.submit() }}</p>
+    </form>
+{% endblock %}

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,8 +1,17 @@
 # This is a whitelist of allowed words for flake8-spellcheck plugin.
 # IMPORTANT: please keep this list alphabetically sorted by whitelisted words
 
-# Linter
+# linter
 pylint
 
-# Stands for 'source' package.
+# stands for `source` package.
 src
+
+# validators
+validators
+
+# part of the name of `flask-wtf` package
+wtf
+
+# `wtforms` python library
+wtforms


### PR DESCRIPTION
In the scope of this task we need to add basic registration page without any functionality. We just need to see registration form when we to according url.

Steps to do:
- add html template with registration form in it (form fields should be: `username`, `password`)
- add flask route for registration page `/register` which renders this form
- add "Sign Up" button to the header of the base template (which will redirect to `/register`)

--------------------------------------------------------------------------------------------------

Working on this task we faced up some linter issues, next will be the description of these problems with accepted solutions:
`flake8` issues arise because it tries to lint our `.html` templates. So to disable that we need to tell `flake8` ignore these files. 
Adding this to `.flake8` config file will help:
```
exclude =
    *.html
    __pycache__
```

`mypy` issues with imports arise because some libraries doesn't have type stubs and `mypy` cannot find them via `mypy --install-types`.
To disable these errors we need to add  following lines to `.mypy` config file:
```
[mypy-flask_wtf.]
ignore_missing_imports = True

[mypy-wtforms.]
ignore_missing_imports = True
filename = ./src/*.py
```

Another `mypy` issue with subclassing `flask_wtf.FlaskForm` arises because `flask_wtf` has no type stubs and any thing imported from untyped library is considered by `mypy` as having type `Any`. Also we have a `--disallow-subclassing-any` option turned on in `mypy`. That's why we have this error.
We could get rid of this error in different ways:
- create stubs containing type hints for the `flask_wtf` library - it's the best solution, but it's really difficult and complex task
- turn off `--disallow-subclassing-any` option in `mypy`, but this will allow us to subclass anything, not only from the untyped libraries - probably not the best solution for us because we're trying to keep `mypy` to be strict as much as possible and cannot disable this option globally for all cases
- turn on `--ignore-missing-imports` option in `mypy`, it will work the same as we type `# type: ignore` for every such case - for now I'm not sure that it is best solution as well, because it will make these things implicit (but probably I'll change my mind later)
- add `# type: ignore` to exact line where error arised (at the line where we trying to subclass from `flask_wtf.FlaskForm`) - seems like it will be our choice now

So as a result of everything written above, we're going to get rid of mypy subclassing `Any` error by adding `# type: ignore` to it:
```python
class RegistrationForm(FlaskForm):  # type: ignore
    ...
```
More info about this `mypy` error you can get here:
- https://stackoverflow.com/questions/49888155/class-cannot-subclass-qobject-has-type-any-using-mypy
- https://stackoverflow.com/questions/52227841/mypy-calls-error-class-cannot-subclass-objecttype-has-type-any-on-graphen

### Requires:
- [x] #4 