### PR TITLE
2: Hotfix allow-global-unused-variables option for pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -91,9 +91,3 @@ spelling-ignore-words=
 # This flag controls whether the implicit-str-concat should generate a warning
 # on implicit string concatenation in sequences defined over several lines.
 check-str-concat-over-line-jumps=yes
-
-
-[VARIABLES]
-
-# Tells whether unused global variables should be treated as a violation.
-allow-global-unused-variables=no


### PR DESCRIPTION
Removed `allow-global-unused-variables=no` because with this option `pylint` will give `unused-variable` error for any thing defined in a python module and not used right there.

Steps to reproduce:
    1. define function `foo()` in a file `module1.py`
    2. import it and use in file `module2.py`
    3. `pylint` will give `unused-variable` error for function `foo()`