### PR TITLE
31: Add docker caching to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,42 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: buildx-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            buildx-${{ runner.os }}-${{ github.ref_name }}
+            buildx-${{ runner.os }}-${{ github.event.repository.default_branch }}
+
       - name: Build linters and application images
         run: |
-          docker-compose -f envs/ci/docker-compose.yml build forum123-build
-          docker-compose -f envs/ci/docker-compose.yml build forum123-mypy
-          docker-compose -f envs/ci/docker-compose.yml build forum123-flake8
-          docker-compose -f envs/ci/docker-compose.yml build forum123-pylint
+          docker compose -f envs/ci/docker-compose.yml --env-file envs/ci/.env build forum123-build
+          docker compose -f envs/ci/docker-compose.yml --env-file envs/ci/.env build forum123-mypy
+          docker compose -f envs/ci/docker-compose.yml --env-file envs/ci/.env build forum123-flake8
+          docker compose -f envs/ci/docker-compose.yml --env-file envs/ci/.env build forum123-pylint
 
       - name: Run mypy
-        run: docker-compose -f envs/ci/docker-compose.yml run forum123-mypy
+        run: docker compose -f envs/ci/docker-compose.yml --env-file envs/ci/.env run forum123-mypy
 
       - name: Run flake8
-        run: docker-compose -f envs/ci/docker-compose.yml run forum123-flake8
+        run: docker compose -f envs/ci/docker-compose.yml --env-file envs/ci/.env run forum123-flake8
 
       - name: Run pylint
-        run: docker-compose -f envs/ci/docker-compose.yml run forum123-pylint
+        run: docker compose -f envs/ci/docker-compose.yml --env-file envs/ci/.env run forum123-pylint
+
+      # This ugly but it's necessary if you don't want your cache to grow forever
+      # until it hits GitHub's limit of 5GB. Because `cache_to` option does not
+      # update the entire Docker cache, but just adds some new layers.
+      # This is a temporary fix. You can read more about this problem here:
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          set -o allexport; source envs/ci/.env; set +o allexport;  # export environment variables from dotenv file
+          rm -rf ${BUILDX_CACHE_SRC}
+          mv ${BUILDX_CACHE_DEST} ${BUILDX_CACHE_SRC}

--- a/envs/ci/.env
+++ b/envs/ci/.env
@@ -1,0 +1,2 @@
+BUILDX_CACHE_SRC="/tmp/.buildx-cache"
+BUILDX_CACHE_DEST="/tmp/.buildx-cache-new"

--- a/envs/ci/Dockerfile
+++ b/envs/ci/Dockerfile
@@ -12,8 +12,8 @@ COPY requirements.txt requirements-dev.txt ./
 
 RUN apt-get update \
     && pip install --upgrade pip \
-    && pip install -r requirements.txt \
-                   -r requirements-dev.txt
+    && pip install --no-cache-dir -r requirements.txt \
+                                  -r requirements-dev.txt
 
 COPY . ./
 

--- a/envs/ci/docker-compose.yml
+++ b/envs/ci/docker-compose.yml
@@ -6,6 +6,10 @@ services:
     build:
       context: ../..  # path from the current file to the project root directory
       dockerfile: envs/ci/Dockerfile  # path from the project root directory to the Dockerfile
+      cache_from:
+        - type=local,src=${BUILDX_CACHE_SRC}
+      cache_to:
+        - type=local,dest=${BUILDX_CACHE_DEST}
 
   forum123-mypy:
     <<: *forum123-build


### PR DESCRIPTION
Now our CI pipeline builds docker images for every run. It takes some time, and we want to make it faster. We need to add a caching of built docker images, to prevent rebuilding image in every run.

In the scope of this task we need to update our images to make them use docker buildx cache, which should be stored in GitHub Cache.

Steps to do:
- add [docker/setup-buildx-action@v2](https://github.com/docker/setup-buildx-action) action to our workflow
  it will allow us to use new docker builder - buildx, which has options `cache_to` and `cache_from`
- bump our `version` in our `envs/ci/docker-compose.yml` up to "3.8"
  it will allow us to use buildx's options `cache_to` and `cache_from` inside our compose file
- use Docker Compose v2 instead of v1
  it will allow us to use buildx builder from docker-compose
  to do that we need to change all `docker-compose` commands in our workflow file to `docker compose`
- setup `cache_to` and `cache_from` to paths where we expect to store our buildx cache
- add [actions/cache@v3](https://github.com/actions/cache) action to our workflow
  it will allow us to use GitHub's cache storage
- add moving buildx cache from directory provided in `cache_to`, to directory provided in `cache_from`
  it is a temporary fix, needed to prevent our buildx cache stored on github to grow uncontrollable
- disable pip caching in dockerfile (use `pip install --no-cache-dir ...`)
  we don't need pip cache since docker has a cache for its layers
  disabling pip caching will allow us to decrease image size and fit more caches into GitHub's 10GB limit

After this task is done, we can continue with CI pipeline optimization by running linters in separated jobs in parallel.