### PR TITLE
37: Speed up linters on CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,15 @@ jobs:
       - name: Cache Docker layers
         uses: ./.github/actions/docker/use-buildx-cache
 
+      - name: Cache mypy
+        uses: actions/cache@v3
+        with:
+          path: ./.mypy_cache
+          key: mypy-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            mypy-${{ runner.os }}-${{ github.ref_name }}
+            mypy-${{ runner.os }}-${{ github.event.repository.default_branch }}
+
       - name: Build mypy
         run: docker compose -f envs/ci/docker-compose.yml --env-file envs/ci/.env build forum123-mypy
 

--- a/envs/ci/docker-compose.yml
+++ b/envs/ci/docker-compose.yml
@@ -13,6 +13,9 @@ services:
 
   forum123-mypy:
     <<: *forum123-build
+    volumes:
+      # bind .mypy_cache to the host in order to store mypy cache in GitHub Cache
+      - ../../.mypy_cache:/forum123/.mypy_cache  # host path is relative to the current docker-compose file
     entrypoint: mypy
 
   forum123-flake8:
@@ -21,4 +24,4 @@ services:
 
   forum123-pylint:
     <<: *forum123-build
-    entrypoint: pylint src
+    entrypoint: pylint --jobs=0 src


### PR DESCRIPTION
We can speed up some of our linters, to make CI respond faster.

Steps to do:
- for mypy use `volumes` to bind `.mypy_cache` dir from mypy container to host and cache it by GitHub
- for pylint use `--jobs=0` to allow pylint to use several processes for run