### PR TITLE
39: Add linter badges to README.md

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,6 +31,22 @@ jobs:
       - name: Update buildx cache
         uses: ./.github/actions/docker/update-buildx-cache
 
+  mypy-badge:
+    name: Mypy badge
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [mypy]
+    steps:
+      - name: Create mypy badge
+        uses: schneegans/dynamic-badges-action@v1.6.0
+        with:
+          auth: ${{ secrets.FORUM123_BADGES_GIST_SECRET }}
+          gistID: daf93d417057585c270ed982ea89fa5d
+          filename: mypy.json
+          label: mypy
+          message: ${{ needs.mypy.result == 'success' && 'passing' || 'failure' }}
+          color: ${{ needs.mypy.result == 'success' && '#238636' || '#6b2a2b' }}
+
   flake8:
     name: Flake8
     runs-on: ubuntu-latest
@@ -50,6 +66,22 @@ jobs:
       - name: Update buildx cache
         uses: ./.github/actions/docker/update-buildx-cache
 
+  flake8-badge:
+    name: Flake8 badge
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [flake8]
+    steps:
+      - name: Create flake8 badge
+        uses: schneegans/dynamic-badges-action@v1.6.0
+        with:
+          auth: ${{ secrets.FORUM123_BADGES_GIST_SECRET }}
+          gistID: daf93d417057585c270ed982ea89fa5d
+          filename: flake8.json
+          label: flake8
+          message: ${{ needs.flake8.result == 'success' && 'passing' || 'failure' }}
+          color: ${{ needs.flake8.result == 'success' && '#238636' || '#6b2a2b' }}
+
   pylint:
     name: Pylint
     runs-on: ubuntu-latest
@@ -68,3 +100,19 @@ jobs:
 
       - name: Update buildx cache
         uses: ./.github/actions/docker/update-buildx-cache
+
+  pylint-badge:
+    name: Pylint badge
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [pylint]
+    steps:
+      - name: Create pylint badge
+        uses: schneegans/dynamic-badges-action@v1.6.0
+        with:
+          auth: ${{ secrets.FORUM123_BADGES_GIST_SECRET }}
+          gistID: daf93d417057585c270ed982ea89fa5d
+          filename: pylint.json
+          label: pylint
+          message: ${{ needs.pylint.result == 'success' && 'passing' || 'failure' }}
+          color: ${{ needs.pylint.result == 'success' && '#238636' || '#6b2a2b' }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Forum123 backend
 
+![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/birthdaysgift/daf93d417057585c270ed982ea89fa5d/raw/mypy.json)
+![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/birthdaysgift/daf93d417057585c270ed982ea89fa5d/raw/flake8.json)
+![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/birthdaysgift/daf93d417057585c270ed982ea89fa5d/raw/pylint.json)
+
 ## Development setup
 
 __This project requires Python 3.10, Docker, Docker Compose.__


### PR DESCRIPTION
We want to show our linter's statuses in README.md via badges.

We considered three ways of doing that:
- [Github](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge) badges
  but Github updates badge too slow, it's about 10 minutes (see [this](https://stackoverflow.com/questions/57719605/official-badge-for-github-actions#answer-57836888)), and allow to create badges only for workflow, but not for a job
- [BYOB](https://github.com/marketplace/actions/bring-your-own-badge) action
  but it uses separate branch too keep badges data (see [this](https://github.com/marketplace/actions/bring-your-own-badge#how-it-works)), and it's not convenient for us 
- [Dynamic Badges](https://github.com/marketplace/actions/dynamic-badges) action
  updates badges in about 5 minutes, uses gist to keep badges data and gives more flexibility for creating badges (for example badge color ranges) - so it's our choice for now

In the scope of this task we need to add badges for mypy, flake8 and pylint to our `README.md`, and make them to be up to date.

### Steps to do:
(most of them from Dynamic Badges [docs](https://github.com/marketplace/actions/dynamic-badges#configuration)):
- create a new gist and name it `flake8.json`. Copy the ID of the gist (this is the long alphanumerical part of its URL)
- go to [github.com/settings/tokens](https://github.com/settings/tokens) and create a new token with the gist scope
- go to the Secrets page of the settings of your repository (Settings > Secrets > Actions) and add this token as a new secret
- add something like the following to your workflow:
  ```yaml
  - name: Create Awesome Badge
    uses: schneegans/dynamic-badges-action@v1.6.0
    with:
      auth: ${{ secrets.GIST_SECRET }}
      gistID: <gist-ID>
      filename: flake8.json
      label: Hello
      message: World
      color: orange
  ```
- add a badge to `README.md` via this link:
  ```
  ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/<user>/<gist-ID>/raw/flake8.json)
  ```
- add badge creation job after each linter's job and bind them using `needs: [ ... ]`
- to make these badge jobs to be executed whatever linter job is succeeded or not use `if: ${{ always() }}`
- you can get linter job results via `needs.<job-id>.result`
  we are interested in only one value here - `'success'`
- to make `message` and `color` to be responsive of the result of your linter run, use following (Github workflow syntax doesn't allow to use ternary operators):
  ```yaml
  color: ${{ needs.mypy.result == 'success' && '#238636' || '#6b2a2b' }}
  ```
  it works the same way as this ternary operator: `needs.mypy.result == 'success' ? '#238636' : '#6b2a2b'`