### PR TITLE
41: Add basic CD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy
+run-name: Deploy commit "${{ github.event.head_commit.message }}"
+
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Run deploy script via ssh
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.PROD_SSH_HOST }}
+          username: ${{ secrets.PROD_SSH_USERNAME }}
+          password: ${{ secrets.PROD_SSH_PASSWORD }}
+          script: |
+            cd /forum123
+            docker compose -f envs/prod/docker-compose.yml down
+
+            # following steps allow us to get the last version of a branch even if it was force pushed
+            git fetch origin develop
+            git checkout -b tmp-branch
+            git branch -D develop
+            git checkout develop
+            git branch -D tmp-branch
+
+            docker compose -f envs/prod/docker-compose.yml up --build --detach

--- a/envs/prod/.gitignore
+++ b/envs/prod/.gitignore
@@ -1,0 +1,2 @@
+# prevent production environment variables to be commited to the repository
+.env

--- a/envs/prod/Dockerfile
+++ b/envs/prod/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.10-slim
+
+WORKDIR /forum123
+
+# Setup and activate python3.10 virtual environment. It will allow us to avoid this warning from pip:
+#     WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system
+#     package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
+RUN python3.10 -m venv .venv
+ENV PATH="/forum123/.venv/bin:$PATH"
+
+COPY requirements.txt requirements-prod.txt ./
+
+RUN apt-get update \
+    && pip install --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt \
+                                  -r requirements-prod.txt
+
+COPY . ./
+
+ENV FLASK_APP=forum123

--- a/envs/prod/Dockerfile.dockerignore
+++ b/envs/prod/Dockerfile.dockerignore
@@ -1,0 +1,15 @@
+# This .dockerignore file works for build context of a Dockerfile placed in the same directory.
+
+# All paths in this file is relative to the build content provided in associated docker-compose.yml.
+# See "build:context" section.
+
+# Please keep this list in alphabetical order.
+
+__pycache__
+
+.mypy_cache
+
+.pytest_cache
+
+# prevent production environment variables to be in image pushed to public docker repository
+envs/prod/.env

--- a/envs/prod/docker-compose.yml
+++ b/envs/prod/docker-compose.yml
@@ -1,0 +1,46 @@
+version: "3.9"
+
+services:
+
+  forum123-app:
+    container_name: forum123-app
+    build: &forum123-app-build
+      context: ../..  # path from the current file to the project root directory
+      dockerfile: envs/prod/Dockerfile  # path from the project root directory to the Dockerfile
+    env_file:
+      - .env
+    depends_on:
+      forum123-db:
+        condition: service_healthy
+    entrypoint: >
+      bash -c "
+        alembic upgrade head
+        gunicorn --config=envs/prod/gunicorn/config.py
+      "
+
+  forum123-db:
+    container_name: forum123-db
+    image: postgres:15
+    env_file:
+      - .env
+    healthcheck:
+      # see: https://github.com/peter-evans/docker-compose-healthcheck#waiting-for-postgresql-to-be-healthy
+      test: [ "CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+      interval: 5s
+      retries: 10
+    volumes:
+      - forum123-prod-db:/var/lib/postgresql/data
+
+  nginx:
+    container_name: forum123-proxy
+    image: nginx:1.23.3-alpine
+    ports:
+      - 80:8080
+    depends_on:
+      - forum123-app
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+
+volumes:
+  forum123-prod-db:
+    name: forum123-prod-db

--- a/envs/prod/gunicorn/config.py
+++ b/envs/prod/gunicorn/config.py
@@ -1,0 +1,9 @@
+accesslog = "-"  # here "-" means stdout
+
+# gunicorn listens all connections but it's still secure
+# since it's run in isolated docker network and only rev-proxy has access to it
+bind = "0.0.0.0:5000"
+
+errorlog = "-"  # here "-" means stdout
+
+wsgi_app = "src:app"

--- a/envs/prod/nginx/nginx.conf
+++ b/envs/prod/nginx/nginx.conf
@@ -1,0 +1,17 @@
+events {}
+
+http {
+
+    server {
+        listen 8080;
+        server_name _;
+
+        location / {
+            proxy_pass http://forum123-app:5000;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Prefix /;
+        }
+    }
+}

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,0 +1,3 @@
+# Production dependencies. Please keep this list in alphabetical order.
+
+gunicorn==20.1.0

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,7 @@
 """Main package for source code."""
 
 from flask import Flask
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from src import routes
 from src.config import Config
@@ -8,3 +9,15 @@ from src.config import Config
 app = Flask(__name__)
 app.register_blueprint(routes.bp)
 app.config.from_object(Config)
+
+
+if Config.PROXIES:
+    # flask app has to know that it's behind a proxy
+    # see: https://flask.palletsprojects.com/en/2.2.x/deploying/proxy_fix/
+    app.wsgi_app = ProxyFix(  # type: ignore
+        app.wsgi_app,
+        x_for=Config.PROXIES_X_FOR,
+        x_proto=Config.PROXIES_X_PROTO,
+        x_host=Config.PROXIES_X_HOST,
+        x_prefix=Config.PROXIES_X_PREFIX,
+    )

--- a/src/config.py
+++ b/src/config.py
@@ -6,6 +6,24 @@ import os
 class Config():  # pylint: disable=too-few-public-methods
     """Configuration class."""
 
-    DATABASE_CONNECTION_URL = os.environ.get("DATABASE_CONNECTION_URL",
-                                             "postgresql://postgres:@localhost:5432/postgres")
+    POSTGRES_DB = os.environ.get("POSTGRES_DB", "postgres")
+    POSTGRES_HOST = os.environ.get("POSTGRES_HOST", "localhost")
+    POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD", "")
+    POSTGRES_PORT = os.environ.get("POSTGRES_PORT", "5432")
+    POSTGRES_USER = os.environ.get("POSTGRES_USER", "postgres")
+
+    PROXIES_X_FOR = int(os.environ.get("PROXIES_X_FOR", 0))
+    PROXIES_X_HOST = int(os.environ.get("PROXIES_X_HOST", 0))
+    PROXIES_X_PREFIX = int(os.environ.get("PROXIES_X_PREFIX", 0))
+    PROXIES_X_PROTO = int(os.environ.get("PROXIES_X_PROTO", 0))
+
     SECRET_KEY = os.environ.get("SECRET_KEY", "bob")
+
+    # next will be listed options derived from the options above
+    # we need some of them to use as an aliases for convenience
+
+    DATABASE_CONNECTION_URL = (
+        f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DB}"
+    )
+
+    PROXIES = any((PROXIES_X_FOR, PROXIES_X_HOST, PROXIES_X_PREFIX, PROXIES_X_PROTO))

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -10,6 +10,9 @@ orm
 # a part of PostgreSQL name
 Postgre
 
+# part of `X-Forwarded-Proto` HTTP header
+proto
+
 # linter
 pylint
 


### PR DESCRIPTION
We want to deploy our changes automatically after merge into develop branch. To do that we need to setup basic Continuous Deployment pipeline.

In the scope of this task we need to create basic Continuous Deployment pipeline to automate deployment process for each push of `develop` branch.

Steps to do:

Docker compose

Add new docker compose setup for prod environment inside `envs/prod` directory with following services: application, database, reverse proxy. Configuration of each service has a detailed description below.

App

- add `gunicorn` to `requirements-prod.txt` it will be used as a WSGI server for our flask app (see [flask docs](https://flask.palletsprojects.com/en/2.2.x/deploying/gunicorn/))
- add a configuration file for gunicorn inside `envs/prod/gunicorn/config.py`
- add a `Dockerfile` which builds our app with `requirements.txt` and `requirements-prod.txt`
- add `envs/prod/Dockerfile.dockerignore` to ignore cache directories and `.env` file with sensitive production data
- add `envs/prod/.gitignore` and ignore `envs/prod/.env` to prevent it to be accidentally commited
- add `env_file` section to app service in docker compose file to provide sensitive data to our application via `.env` file
- add `depends_on` section to make our app depend on database service
- add `entrypoint` section which should run first apply migrations and the run gunicorn with our config

Yes, we decided to use the simplest db migration model, when applying migration happens in the app container before the application start. It's not a good practice for big and distributed infrastructures which also cares about zero-downtime deployment and data consistency between migrations. More about the correct approach for doing migrations in production environment you can read [here](https://pythonspeed.com/articles/schema-migrations-server-startup/). Now our simplest approach we choose is sufficient for our needs.

Also we didn't expose any ports because we want our app to run under reverse proxy. So all external requests will come to our reverse proxy and after that will be redirected to our app. Therefore our app will be connected only to reverse proxy server inside docker network.

Database

- update `src/config.py` to have a different environment variable `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER` and `POSTGRES_DB` since postgres image requires these variables it will be more convenient if our application will work with same variables too, and we will be able to provide one `.env` file to both - application and database
- add `healthcheck` to postgres container (see [this](https://github.com/peter-evans/docker-compose-healthcheck#waiting-for-postgresql-to-be-healthy)) also we need to provide `POSTGRES_USER` and `POSTGRES_DB` to healthcheck script to avoid `FATAL: role "root" does not exist` issue (see [this](https://github.com/peter-evans/docker-compose-healthcheck/issues/16))
- add a volume to keep our production db data

Reverse proxy

- add `nginx` service to docker compose file, we will use it as a reverse proxy (see [flask docs](https://flask.palletsprojects.com/en/2.2.x/deploying/nginx/))
- add `envs/prod/nginx/nginx.conf` with simple configuration from [flask docs](https://flask.palletsprojects.com/en/2.2.x/deploying/nginx/#configuration)
- provide nginx config to nginx container via volumes (`./nginx/nginx.conf:/etc/nginx/nginx.conf:ro`)
- expose 80 port to make it externally accessible
- add reverse proxy configuration to flask (see [flask docs](https://flask.palletsprojects.com/en/2.2.x/deploying/proxy_fix/)) to be able to change this configuration we will make these proxy options to be configurable via env variables and add them to our `src/config.py`

VPS

To host our application we need to find a VPS and configure it. We decided to deploy application to our production host via simple commands run through ssh. From our GitHub workflow we want to execute some commands via ssh to do these steps: stop running containers, fetch last repository changes from Github, run containers with last changes (with `--build` option). So to be able to do that, we need to setup our VPS host:
- install [docker-desktop](https://docs.docker.com/desktop/install/ubuntu/#install-docker-desktop)
- install [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) and [configure](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup#_your_identity) username and email for it
- generate new ssh key for our production host and add it to GitHub (see [docs](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent))
- clone our repository to `/forum123` directory
- create `/forum123/envs/prod/.env` file and provide all configuration options listed in our `src/config.py`

After installing docker we had a problem with `docker.sock`, and [this](https://stackoverflow.com/questions/43569781/unable-to-start-docker-service-with-error-failed-to-start-docker-service-unit/43576628#43576628) SO answer was really helpful.

After trying to run our docker services on VPS we got error saying that port 80 has been occupied already. It was because apache server running on this port. So we had to disable it (see [this](https://www.cyberciti.biz/faq/star-stop-restart-apache2-webserver/)).

Deploy workflow
- add `PROD_SSH_HOST`, `PROD_SSH_USERNAME` and `PROD_SSH_PASSWORD` GitHub secrets for this repo
- add a `.github/workflows/deploy.yml` workflow which should run on every push to `develop` branch
- add checkout action to our workflow
- add [ssh action](https://github.com/appleboy/ssh-action) which will use our secrets to connect via ssh and execute commands on the production host machine

We wanted to use environment variables `PROD_APP_ROOT` and `DEPLOY_BRANCH_NAME` in our script running through ssh, but faced with problems that seemed to be unresolved for that moment (see [issue](https://github.com/appleboy/ssh-action/issues/58)).

Also we haven't found a solution to put all commands we want to run via ssh to a separate `.sh` file and use in this action. Since these command will be run on host machine but this `.sh` file will be in our CI environment running this deploy workflow. The one way to do that could be - first move our `.sh` deployment script to host and then run something like `source ./deploy.sh` via ssh. But we didn't want to deal with `scp` action in our wokflow and decided to do it in a simpler way - just write all commands in our `ssh` github action as is.