### PR TITLE
43: Add deploy badge to README.md

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,3 +31,19 @@ jobs:
             git branch -D tmp-branch
 
             docker compose -f envs/prod/docker-compose.yml up --build --detach
+
+  deploy-badge:
+    name: Deploy badge
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [deploy]
+    steps:
+      - name: Create deploy badge
+        uses: schneegans/dynamic-badges-action@v1.6.0
+        with:
+          auth: ${{ secrets.FORUM123_BADGES_GIST_SECRET }}
+          gistID: daf93d417057585c270ed982ea89fa5d
+          filename: deploy.json
+          label: deploy
+          message: ${{ needs.deploy.result == 'success' && 'passing' || 'failure' }}
+          color: ${{ needs.deploy.result == 'success' && '#238636' || '#6b2a2b' }}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/birthdaysgift/daf93d417057585c270ed982ea89fa5d/raw/mypy.json)
 ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/birthdaysgift/daf93d417057585c270ed982ea89fa5d/raw/flake8.json)
 ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/birthdaysgift/daf93d417057585c270ed982ea89fa5d/raw/pylint.json)
+![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/birthdaysgift/daf93d417057585c270ed982ea89fa5d/raw/deploy.json)
 
 ## Development setup
 


### PR DESCRIPTION
We want to show our deploy status in README.md.

In the scope of this task we need to add badges for deploy to our README.md, and make it to be up to date.

Steps to do:
    - add new job to our `.github/workflows/deploy.yml` which will create a badge
      it should be done in the same way we did it for linter badges
    - add a link to the badge in README.md