### PR TITLE
43: Add rebase gitflow checks to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -116,3 +116,18 @@ jobs:
           label: pylint
           message: ${{ needs.pylint.result == 'success' && 'passing' || 'failure' }}
           color: ${{ needs.pylint.result == 'success' && '#238636' || '#6b2a2b' }}
+
+  branch:
+    name: Branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out whole repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # fetch all history for all branches and tags
+
+      - name: Lint branch
+        env:
+          GITHUB_CURRENT_BRANCH: ${{ github.ref_name }}
+          GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: python envs/ci/scripts/branches/lint.py

--- a/envs/ci/scripts/branches/lint.py
+++ b/envs/ci/scripts/branches/lint.py
@@ -1,0 +1,53 @@
+"""This script checks that current branch satisfies our custom gitflow rules."""
+
+import os
+import subprocess
+import sys
+
+
+GITHUB_CURRENT_BRANCH = os.environ["GITHUB_CURRENT_BRANCH"]
+GITHUB_DEFAULT_BRANCH = os.environ["GITHUB_DEFAULT_BRANCH"]
+
+
+def main():
+    errors = get_errors()
+    if errors:
+        print("Following errors were found:")
+        for error in errors:
+            print(f"  * {error}")
+        sys.exit(1)
+    print("No errors were found.")
+    sys.exit(0)
+
+
+def get_errors():
+    """Run checkers and get error messages."""
+    errors = []
+    if not branch_rebased():
+        errors.append("Branch is not rebased.")
+    if not commits_squashed():
+        errors.append("Commits are not squashed.")
+    return errors
+
+
+def branch_rebased():
+    """Check that current branch is rebased to the last default branch."""
+    cmd = subprocess.run(["git", "merge-base", "--fork-point", f"origin/{GITHUB_DEFAULT_BRANCH}"], capture_output=True)
+    current_branch_fork_point = cmd.stdout.decode("utf-8").strip("\n")
+
+    cmd = subprocess.run(["git", "rev-parse", f"origin/{GITHUB_DEFAULT_BRANCH}"], capture_output=True)
+    default_branch_last_commit = cmd.stdout.decode("utf-8").strip("\n")
+
+    return current_branch_fork_point == default_branch_last_commit
+
+
+def commits_squashed():
+    """Check that current branch has only one commit."""
+    cmd = subprocess.run(["git", "cherry", f"origin/{GITHUB_DEFAULT_BRANCH}"], capture_output=True, encoding="utf-8")
+    commits = cmd.stdout.strip("\n").split("\n")
+
+    return len(commits) == 1
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Since we work with git via rebase strategy we want to prevent non-rebased branches to be merged into develop. To achieve that we can add a new GitHub workflow which will check whether branch is rebased on last develop or not.

In the scope of this task we need to following checks to our CI:
- branch is rebased
- commits are squashed

Steps to do:
- write a python script `envs/ci/scripts/branches/lint.py` which runs checks and prints errors
  it should also return 0 in case of no errors and 1 otherwise 
- add a new job to `.github/workflows/lint.yml` which runs our script