### PR TITLE
24: Add topic creation page

### DIFF
--- a/src/forms.py
+++ b/src/forms.py
@@ -1,7 +1,7 @@
 """forum123's forms module."""
 
 from flask_wtf import FlaskForm
-from wtforms import PasswordField, StringField, SubmitField
+from wtforms import PasswordField, StringField, SubmitField, TextAreaField
 from wtforms.validators import DataRequired
 
 
@@ -19,3 +19,11 @@ class LoginForm(FlaskForm):  # type: ignore
     username = StringField("Username", validators=[DataRequired()])
     password = PasswordField("Password", validators=[DataRequired()])
     submit = SubmitField("Sign In")
+
+
+class TopicForm(FlaskForm):  # type: ignore
+    """A class for a topic creation form."""
+
+    title = TextAreaField("Title", validators=[DataRequired()])
+    description = TextAreaField("Description", validators=[DataRequired()])
+    submit = SubmitField("Create topic")

--- a/src/routes.py
+++ b/src/routes.py
@@ -9,7 +9,7 @@ from flask import Blueprint
 from flask import make_response, redirect, render_template, request, url_for
 
 from src.database import session
-from src.forms import LoginForm, RegistrationForm
+from src.forms import LoginForm, RegistrationForm, TopicForm
 from src.models import Topic, User, UserSession
 
 if TYPE_CHECKING:
@@ -86,3 +86,17 @@ def topics() -> str | Response:
         topic_list = session.query(Topic).order_by(Topic.created_at.desc()).all()
         return render_template("topics.html", topic_list=topic_list, current_user=current_user)
     return redirect(url_for("routes.login"))
+
+
+@bp.route("/topics/create")
+def create_topic() -> str:
+    """Handle create topic page."""
+    session_id = request.cookies.get("session_id")
+    user_session = session.query(UserSession).filter_by(session_id=session_id).first()
+
+    current_user = None
+    if user_session is not None:
+        current_user = session.query(User).filter_by(id=user_session.user_id).one()
+
+    form = TopicForm()
+    return render_template("topics-create.html", form=form, current_user=current_user)

--- a/src/templates/topics-create.html
+++ b/src/templates/topics-create.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>Create topic</h1>
+    <form id="1" method="POST" action="" novalidate>
+        {{ form.hidden_tag() }}
+        <p>
+            {{ form.title.label }}<br>
+            {{ form.title(size=30) }}
+        </p>
+        <p>
+            {{ form.description.label }}<br>
+            {{ form.description(size=120) }}
+        </p>
+        <p>{{ form.submit() }}</p><button form="1" type="reset"><a href="{{ url_for('routes.topics') }}">Cancel</a></button>
+    </form>
+{% endblock %}

--- a/src/templates/topics.html
+++ b/src/templates/topics.html
@@ -1,7 +1,9 @@
 {% extends "base.html" %}
 
 {% block content %}
+    <h1><a href="{{ url_for('routes.create_topic') }}">Create topic</a></h1>
     {% for topic in topic_list %}
+    <br>
         <ul>
             <li><b>{{ topic.title }}</b></li>
             <li>{{ topic.description }}</li>


### PR DESCRIPTION
After we've created `Topic` model and added an ability to see created topics (#23), we can go further and start implementing topics creation. 

In the scope of this task we need add to basic topic creation page without any functionality. We just need to see creation form when we go to `/topics/create`)

### Steps to do:
- add html template with topic creation form in it (form fields should be: `title`, `description`)
- add `Cancel` button, which will clear form data (idk is it required or not) and redirect to `/topics`
- add flask route for topic creation page `/topics/create` which renders this form
- add "Create topic" button to the `/topics` page template and make it point to `/topics/create`
