### PR TITLE
26: Add topic page

### DIFF
--- a/src/routes.py
+++ b/src/routes.py
@@ -105,3 +105,17 @@ def create_topic() -> str | Response:
             return redirect(url_for("routes.topics"))
         return render_template("topics-create.html", form=form, current_user=current_user)
     return redirect(url_for("routes.login"))
+
+
+@bp.route("/topics/<int:topic_id>")
+def topic_page(topic_id: int) -> str | Response:
+    """Handle topic page."""
+    session_id = request.cookies.get("session_id")
+    user_session = session.query(UserSession).filter_by(session_id=session_id).first()
+
+    current_user = None
+    if user_session is not None:
+        current_user = session.query(User).filter_by(id=user_session.user_id).one()
+        topic = session.query(Topic).filter_by(id=topic_id).first()
+        return render_template("topic.html", current_user=current_user, topic=topic)
+    return redirect(url_for("routes.login"))

--- a/src/templates/topic.html
+++ b/src/templates/topic.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <b><p>{{ topic.author.username }} says:</p></b>
+    <br>
+    <h1>{{ topic.title }}</h1>
+    <br>
+    <p>{{ topic.description }}</p>
+    <br>
+    <p>{{ topic.created_at }}</p>
+{% endblock %}

--- a/src/templates/topics.html
+++ b/src/templates/topics.html
@@ -5,7 +5,7 @@
     {% for topic in topic_list %}
     <br>
         <ul>
-            <li><b>{{ topic.title }}</b></li>
+            <li><b><a href="{{ url_for('routes.topic_page', topic_id=topic.id) }}">{{ topic.title }}</a></b></li>
             <li>{{ topic.description }}</li>
             <li>{{ topic.author.username }}</li>
             <li>at {{ topic.created_at }}</li>


### PR DESCRIPTION
After we've added topics creation (#25) and ability to see list of created topics (#23), we can go further and add a page for topic itself.

In the scope of this task we need to add an ability to see topic content at `/topics/{topic_id}`. For now it will only be author, title, description and creation date (no posts listed for now)

Steps to do:
- add a template for topic page
- add a router for `/topics/{topic_id}` which will get topic from database and return correct template rendered
- add an ability to go to the appropriate topic page by the link for each topic in `/topics`