### PR TITLE
28: Add post creation page

### DIFF
--- a/src/forms.py
+++ b/src/forms.py
@@ -27,3 +27,10 @@ class TopicForm(FlaskForm):  # type: ignore
     title = TextAreaField("Title", validators=[DataRequired()])
     description = TextAreaField("Description", validators=[DataRequired()])
     submit = SubmitField("Create topic")
+
+
+class PostForm(FlaskForm):  # type: ignore
+    """A class for a post creation form."""
+
+    body = TextAreaField("Body", validators=[DataRequired()])
+    submit = SubmitField("Create post")

--- a/src/routes.py
+++ b/src/routes.py
@@ -9,7 +9,7 @@ from flask import Blueprint
 from flask import make_response, redirect, render_template, request, url_for
 
 from src.database import session
-from src.forms import LoginForm, RegistrationForm, TopicForm
+from src.forms import LoginForm, PostForm, RegistrationForm, TopicForm
 from src.models import Topic, User, UserSession
 
 if TYPE_CHECKING:
@@ -118,4 +118,19 @@ def topic_page(topic_id: int) -> str | Response:
         current_user = session.query(User).filter_by(id=user_session.user_id).one()
         topic = session.query(Topic).filter_by(id=topic_id).first()
         return render_template("topic.html", current_user=current_user, topic=topic)
+    return redirect(url_for("routes.login"))
+
+
+@bp.route("/topics/<int:topic_id>/posts/create", methods=["POST", "GET"])
+def create_post(topic_id: int) -> str | Response:
+    """Handle post creation page."""
+    session_id = request.cookies.get("session_id")
+    user_session = session.query(UserSession).filter_by(session_id=session_id).first()
+
+    current_user = None
+    if user_session is not None:
+        current_user = session.query(User).filter_by(id=user_session.user_id).one()
+        form = PostForm()
+        topic = session.query(Topic).filter_by(id=topic_id).first()
+        return render_template("posts-create.html", form=form, topic=topic, current_user=current_user)
     return redirect(url_for("routes.login"))

--- a/src/templates/posts-create.html
+++ b/src/templates/posts-create.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>Create post</h1>
+    <form id="1" method="POST" action="" novalidate>
+        {{ form.hidden_tag() }}
+        <p>
+            {{ form.body.label }}<br>
+            {{ form.body(size=123) }}
+        </p>
+        <p>{{ form.submit() }}</p><button form="1" type="reset"><a href="{{ url_for('routes.topic_page', topic_id=topic.id) }}">Cancel</a></button>
+    </form>
+{% endblock %}

--- a/src/templates/topic.html
+++ b/src/templates/topic.html
@@ -17,4 +17,5 @@
             <li>at {{ post.created_at }}</li>
         </ul>
     {% endfor %}
+    <a href="{{ url_for('routes.create_post', topic_id=topic.id) }}">Create Post</a>
 {% endblock %}


### PR DESCRIPTION
After we've created `Post` model and added an ability to see created posts in topic (#27), we can go further and start implementing posts creation. 

In the scope of this task we need add to basic post creation page without any functionality. We just need to see creation form when we go to `/topics/{topic_id}/posts/create`)

### Steps to do:
- add html template with post creation form in it (form fields should be: `body`)
- add `Cancel` button, which will clear form data (idk is it required or not) and redirect to `/topics/{topic_id}`
- add flask route for post creation page `/topics/{topic_id}/posts/create` which renders this form
- add "Create post" button to the `/topics/{topic_id}` page and make it point to `/topics/{topic_id}/create`
  button should be placed at the bottom of the page `/topics/{topic_id}`
