### PR TITLE
55: Add error handling for topic routes

### DIFF
--- a/src/routes.py
+++ b/src/routes.py
@@ -116,13 +116,14 @@ def topic_page(topic_id: int) -> str | Response:
     current_user = None
     if user_session is not None:
         current_user = session.query(User).filter_by(id=user_session.user_id).one()
-        topic = session.query(Topic).filter_by(id=topic_id).first()
+        if not (topic := session.query(Topic).filter_by(id=topic_id).first()):
+            return render_template("404.html", current_user=current_user)
         return render_template("topic.html", current_user=current_user, topic=topic)
     return redirect(url_for("routes.login"))
 
 
 @bp.route("/topics/<int:topic_id>/posts/create", methods=["POST", "GET"])
-def create_post(topic_id: int) -> str | Response:
+def create_post(topic_id: int) -> str | Response:  # noqa: CFQ004
     """Handle post creation page."""
     session_id = request.cookies.get("session_id")
     user_session = session.query(UserSession).filter_by(session_id=session_id).first()
@@ -131,7 +132,8 @@ def create_post(topic_id: int) -> str | Response:
     if user_session is not None:
         current_user = session.query(User).filter_by(id=user_session.user_id).one()
         form = PostForm()
-        topic = session.query(Topic).filter_by(id=topic_id).first()
+        if not (topic := session.query(Topic).filter_by(id=topic_id).first()):
+            return render_template("404.html", current_user=current_user)
         if topic and form.validate_on_submit():
             new_post = Post(body=form.body.data, author_id=current_user.id, topic_id=topic.id)
             session.add(new_post)

--- a/src/templates/404.html
+++ b/src/templates/404.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>Error 404: NOT FOUND</h1>
+{% endblock %}


### PR DESCRIPTION
While developing topic routes (#26, #28), we totally forgot about handling cases when requested topic doesn't exist.

These two routes 
```python
@bp.route("/topics/<int:topic_id>")
def topic_page(topic_id: int) -> str | Response:
    ...
```
```python
@bp.route("/topics/<int:topic_id>/posts/create", methods=["POST", "GET"])
def create_post(topic_id: int) -> str | Response:
    ...
```
expect topic id as a path variable, but user can provide any number. So if topic with such id doesn't exist, we should return an error page.

In the scope of this task we need to handle "nonexistent topic" cases for the routes mentioned above.

Steps to do:
- add html template which will represent 404 error page
- update `topic_page` and `create_post` routes, to make them return 404 error page if topic doesn't exist