### PR TITLE
58: Add unit-testing layout

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,16 @@
+[run]
+branch = True
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if TYPE_CHECKING:
+
+
+show_missing = True
+
+skip_covered = True
+skip_empty = True
+
+[html]
+show_contexts = True

--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,8 @@
 [flake8]
 
-filename = ./src/*
+filename =
+    ./src/*,
+    ./tests/*,
 
 exclude =
     *.html,
@@ -20,6 +22,28 @@ ignore =
     S101,  # Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
     W503,  # Line break occurred before a binary operator.
 
+per-file-ignores =
+    # files with tests
+    tests/*test_*:
+        # Absence of function annotations and type comments
+        ANN,
+        # Missing docstring
+        D,
+        # local variable {variable} is assigned to but never used
+        F841,
+
+     # files with fixtures
+    tests/*conftest.py:
+        # Absence of function annotations and type comments
+        ANN,
+        # Missing docstring
+        D,
+
+    # files with unit-testing utilities
+    tests/utils/*:
+        # Absence of function annotations and type comments
+        ANN,
+
 # NEXT WILL BE LISTED SOME OPTIONS USED BY PLUGINS
 # PLEASE KEEP THIS LIST SORTED BY PLUGIN NAMES ALPHABETICALLY
 
@@ -31,7 +55,7 @@ docstring_style = sphinx
 strictness = short
 
 # flake8-import-order ==================================================================================================
-application-import-names = src
+application-import-names = src,tests
 # Controls what style the plugin follows.
 import-order-style = smarkets
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__
+
+.coverage

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ Linters order above is the preffered way to run and fix them one by one.
 5. Open http://127.0.0.1:5000 in your internet browser.
 
 
+### Run tests
+
+1. Open terminal
+2. Run services using `docker-compose -f envs/test/docker-compose.yml up --detach` command.
+3. Type `pytest` command in terminal.
+   If you want to check coverage, run `pytest --cov=src`. This command also creates `htmlcov/index.html` file,
+   which you can open in your browser and look at the html report.
+
 
 ### Working with migrations
 

--- a/envs/test/docker-compose.yml
+++ b/envs/test/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.8"
+
+services:
+  forum123-db:
+    image: postgres:latest
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
+    ports:
+      - 127.0.0.1:5433:5432
+    volumes:
+      - forum123-db-test:/var/lib/postgresql/data
+
+volumes:
+  forum123-db-test:
+    name: forum123-db-test

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+addopts =
+    --cov-context=test
+    --cov-report=html
+    --cov-report=term
+
+env =
+    POSTGRES_PORT=5433
+
+pythonpath = .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@
 
 darglint==1.8.1  # Checks whether a docstring's description matches the actual function/method implementation
 dlint==0.12.0  # Tool for encouraging best coding practices and helping ensure Python code is secure.
+flake8-aaa==0.12.2  # Lints tests against the Arrange Act Assert pattern.
 flake8-absolute-import==1.0  # Plugin to require absolute imports.
 flake8-annotations==2.7.0  # Plugin for flake8 to check for presence of type annotations in function definitions.
 flake8-annotations-complexity==0.0.6  # Plugin to validate annotations complexity.
@@ -29,6 +30,8 @@ flake8-type-checking==1.0.3  # Plugin for managing type-checking imports & forwa
 flake8==3.9.2
 mypy==0.991
 pylint==2.15.9
+pytest==7.2.0
+pytest-cov==4.0.0
 sqlalchemy[mypy]==1.4.46
 
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -11,7 +11,7 @@ app.register_blueprint(routes.bp)
 app.config.from_object(Config)
 
 
-if Config.PROXIES:
+if Config.PROXIES:  # pragma: no cover
     # flask app has to know that it's behind a proxy
     # see: https://flask.palletsprojects.com/en/2.2.x/deploying/proxy_fix/
     app.wsgi_app = ProxyFix(  # type: ignore

--- a/src/database.py
+++ b/src/database.py
@@ -1,5 +1,7 @@
 """Periferals required for SQLAlchemy to function."""
 
+import contextvars
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import declarative_base, scoped_session, sessionmaker
 
@@ -12,8 +14,13 @@ config = Config()
 engine = create_engine(config.DATABASE_CONNECTION_URL)
 
 # will allow us to send SQL queries to database associated with engine
-session = scoped_session(sessionmaker(bind=engine))
+_session = scoped_session(sessionmaker(bind=engine))
 
 # will allow us to map relation tables from PostgreSQL to python classes
 # each model must inherit this Base class
 Base = declarative_base()
+
+
+# will allow us to easily patch db session for test environment
+# via session_var.set() and session_var.get()
+session_var = contextvars.ContextVar("session", default=_session)

--- a/src/routes.py
+++ b/src/routes.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from flask import Blueprint
 from flask import make_response, redirect, render_template, request, url_for
 
-from src.database import session
+from src.database import session_var
 from src.forms import LoginForm, PostForm, RegistrationForm, TopicForm
 from src.models import Post, Topic, User, UserSession
 
@@ -19,10 +19,20 @@ if TYPE_CHECKING:
 bp = Blueprint("routes", __name__)
 
 
+@bp.route("/check-unit-tests", methods=["POST"])
+def check_unit_tests() -> str:
+    """Route to check that application works correctly in unit-testing environment."""
+    session = session_var.get()
+    session.add(User(username="user from app", password_hash="password"))
+    session.commit()
+    return render_template("user_created.html")
+
+
 @bp.route("/")
 @bp.route("/index")
 def index() -> str:
     """Handle index page."""
+    session = session_var.get()
     users = session.query(User).all()
     session_id = request.cookies.get("session_id")
     user_session = session.query(UserSession).filter_by(session_id=session_id).first()
@@ -37,6 +47,7 @@ def index() -> str:
 @bp.route("/registration", methods=["POST", "GET"])
 def registration() -> str:
     """Handle user's registration form."""
+    session = session_var.get()
     form = RegistrationForm()
     if form.validate_on_submit():
         user = User(username=form.username.data)
@@ -49,6 +60,7 @@ def registration() -> str:
 @bp.route("/login", methods=["POST", "GET"])
 def login() -> str | Response:
     """Handle user's login form."""
+    session = session_var.get()
     form = LoginForm()
     if form.validate_on_submit():
         user = session.query(User).filter_by(username=form.username.data).first()
@@ -67,6 +79,7 @@ def login() -> str | Response:
 @bp.route("/logout")
 def logout() -> Response:
     """Log out users."""
+    session = session_var.get()
     session_id = request.cookies.get("session_id")
     if session_to_delete := session.query(UserSession).filter_by(session_id=session_id).first():
         session.delete(session_to_delete)
@@ -77,6 +90,7 @@ def logout() -> Response:
 @bp.route("/topics")
 def topics() -> str | Response:
     """Handle topics page."""
+    session = session_var.get()
     session_id = request.cookies.get("session_id")
     user_session = session.query(UserSession).filter_by(session_id=session_id).first()
 
@@ -91,6 +105,7 @@ def topics() -> str | Response:
 @bp.route("/topics/create", methods=["POST", "GET"])
 def create_topic() -> str | Response:
     """Handle create topic page."""
+    session = session_var.get()
     session_id = request.cookies.get("session_id")
     user_session = session.query(UserSession).filter_by(session_id=session_id).first()
 
@@ -110,6 +125,7 @@ def create_topic() -> str | Response:
 @bp.route("/topics/<int:topic_id>")
 def topic_page(topic_id: int) -> str | Response:
     """Handle topic page."""
+    session = session_var.get()
     session_id = request.cookies.get("session_id")
     user_session = session.query(UserSession).filter_by(session_id=session_id).first()
 
@@ -125,6 +141,7 @@ def topic_page(topic_id: int) -> str | Response:
 @bp.route("/topics/<int:topic_id>/posts/create", methods=["POST", "GET"])
 def create_post(topic_id: int) -> str | Response:  # noqa: CFQ004
     """Handle post creation page."""
+    session = session_var.get()
     session_id = request.cookies.get("session_id")
     user_session = session.query(UserSession).filter_by(session_id=session_id).first()
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Package for unit-tests."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+import pytest
+from alembic.config import main as alembic
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+from src import app
+from src.database import engine, session_var
+from src.models import User
+from tests.utils.database import set_autoincrement_counters
+
+
+def pytest_sessionstart(session):
+    alembic(["upgrade", "head"])
+    set_autoincrement_counters()
+
+
+@pytest.fixture
+def client():
+    with app.test_client() as client, app.app_context():
+        return client
+
+
+@pytest.fixture
+def db_empty():
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = scoped_session(sessionmaker(bind=connection))
+    session_var.set(session)
+    yield session
+    transaction.rollback()
+    session.remove()
+    connection.close()
+
+
+@pytest.fixture
+def db_with_one_user(db_empty):
+    session = db_empty
+    session.add(User(id=1, username="user from fixture", password_hash="password"))
+    session.commit()
+    return session

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,26 @@
+from unittest.mock import patch
+
+from src.models import User
+
+
+def test_check_unit_tests_renders_template_correctly(client, db_empty):
+    with patch("src.routes.render_template") as render_template:
+
+        result = client.post("/check-unit-tests")
+
+    assert result.status_code == 200
+    render_template.assert_called_once_with("user_created.html")
+
+
+def test_check_unit_tests_creates_user_correctly(client, db_with_one_user):
+    session = db_with_one_user
+    with patch("src.routes.render_template"):
+
+        result = client.post("/check-unit-tests")
+
+    users_query = session.query(User)
+    assert len(users_query.all()) == 2
+    new_user = users_query.order_by(User.id.desc()).first()
+    assert isinstance(new_user.id, int) and new_user.id > 0
+    assert new_user.username == "user from app"
+    assert new_user.password_hash == "password"

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Some utils for unit-testing."""

--- a/tests/utils/database.py
+++ b/tests/utils/database.py
@@ -1,0 +1,28 @@
+"""Database utils."""
+
+from sqlalchemy import text
+
+from src.database import Base, engine
+
+
+def set_autoincrement_counters():
+    """Set initial value for all autoincremented sequences in db tables.
+
+    This is needed to avoid conflicts between rows created by fixtures
+    and values created by the app itself.
+
+    For example:
+        fixture creates a new user with id = 1
+        test calls application endpoint which will create another user
+        since id column in fixtures was provided by hands, then
+        autoincrement key is not switched to the next value and user created by
+        application will have id = 1 as well. This will cause and error
+        because application is trying to add a user with primary key which already exists.
+
+    So this function just sets autoincrement counter for `id` columns in all database tables.
+    """
+    queries = ""
+    for tablename in Base.metadata.tables.keys():
+        queries += f"ALTER SEQUENCE {tablename}_id_seq RESTART WITH 10000;"
+    with engine.connect() as connection:
+        connection.execute(text(queries))

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,6 +1,12 @@
 # This is a whitelist of allowed words for flake8-spellcheck plugin.
 # IMPORTANT: please keep this list alphabetically sorted by whitelisted words
 
+# auto increment
+autoincrement
+
+# context variables (python standard library)
+contextvars
+
 # SQLAlchemy method - short for `descending`
 desc
 
@@ -25,6 +31,9 @@ pylint
 # sessionmaker
 sessionmaker
 
+# session start (used in `pytest`)
+sessionstart
+
 # stands for `source` package.
 src
 
@@ -34,8 +43,14 @@ sqlalchemy
 # a name of a database table
 tablename
 
+# unit-test (used by python standard library)
+unittest
+
 # SQLAlchemy parameter name
 uselist
+
+# utilities
+utils
 
 # validators
 validators


### PR DESCRIPTION
To start writing unit-test and check the coverage we need to do some preparation steps and setup "testing environment" correctly.

Main concerns:
- create separate database for tests
  because we don't want our unit-tests to change data in dev database
- patch database session for tests and application to "transact session"
  "transact session" is a session which will be rollbacked after each test, in order to clean up db after test
- add coverage tools to be able to see coverage
  setup to check branch coverage and create html and "console" reports

So in the scope of this task we need to setup `pytest` with `pytest-cov`, write a simple endpoint and write a test for it, to be sure that everything works fine together.

### Steps to do:
- add new `envs/test/docker-compose.yml` file which will contain a description of testing database
  this database should run on another port (not 5432 as our dev db), and use a separate volume to store data
- add simple endpoint which will create one user in database and render nonexistent template
  it is needed to check that our application works with patched session correctly, when we will write a test for it
- add `pytest`, `pytest-env` and `flake8-aaa` to `requirements-dev.txt` and install them locally
- add `tests/conftest.py` file and create an application and transact session (empty db) fixtures in it
- add `pytest_sessionstart` hook and use it to apply migrations and set autoincremented counters in database
- create a db fixture with one user in it
  it is needed to check that our fixtures works with patched session correctly, when we will write a test for it
- add `pytest.ini` file and set correct `POSTGRES_PORT` and `pythonpath`
- change `session` in `src.database` to be `ContextVar` object
  it will help us to patch this session
- update all endpoints which use this session, to get a value from context var
- add setting up correct session context var in our transact session
- write two tests, one to check template rendering, second to check database interactions
- add `pytest-cov` to `requirements-dev.txt` and install it locally
- configure pytest via `pytest.ini` to add dynamic contexts, and create two types of reports - html and term 
- configure coverage via `.coveragerc` to run branch coverage, exclude type imports and `pragma: no cover`, skip covered, skip empty and show contexts
- add `.coverage` file to `.gitignore`
- update `.flake8` to also check `tests` directory, with some exceptions from common rules
- update `README.md`