### PR TITLE
61: Add redirect for registration page

### DIFF
--- a/src/routes.py
+++ b/src/routes.py
@@ -45,7 +45,7 @@ def index() -> str:
 
 
 @bp.route("/registration", methods=["POST", "GET"])
-def registration() -> str:
+def registration() -> str | Response:
     """Handle user's registration form."""
     session = session_var.get()
     form = RegistrationForm()
@@ -54,6 +54,7 @@ def registration() -> str:
         user.set_password(form.password.data)
         session.add(user)
         session.commit()
+        return redirect(url_for("routes.login"))
     return render_template("registration.html", form=form)
 
 


### PR DESCRIPTION
During developing registration functionality (#9) we forgot to add redirect after successful registration.

So in the scope of this task we need to add redirect to login page after successful registration.

### Steps to do:
- add redirect to login page in `/register` router