### PR TITLE
67: Encapsulate models deletion

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -57,6 +57,12 @@ class UserSession(Base):  # pylint: disable=too-few-public-methods
     session_id = Column(String, nullable=False, unique=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
 
+    def delete(self) -> None:
+        """Use this method to delete a user session."""
+        session = session_var.get()
+        session.delete(self)
+        session.commit()
+
 
 class Topic(Base):
     """A model class for topics table."""

--- a/src/routes.py
+++ b/src/routes.py
@@ -74,8 +74,7 @@ def logout() -> Response:
     session = session_var.get()
     session_id = request.cookies.get("session_id")
     if session_to_delete := session.query(UserSession).filter_by(session_id=session_id).first():
-        session.delete(session_to_delete)
-        session.commit()
+        session_to_delete.delete()
     return redirect(url_for("routes.login"))
 
 


### PR DESCRIPTION
In order to separate application layers we need to move all "low-level" database related code into models.

In the scope of this task we need to encapsulate all models deletion functionality into models methods. We need to get rid of using session.delete() and session.commit() in our routes, because this is a database layer responsibility.