### PR TITLE
76: Remove unused topic check in if-statement

### DIFF
--- a/src/routes.py
+++ b/src/routes.py
@@ -121,7 +121,7 @@ def create_post(topic_id: int) -> str | Response:  # noqa: CFQ004
     form = PostForm()
     if not (topic := Topic.get(topic_id)):
         return render_template("404.html", current_user=current_user)
-    if topic and form.validate_on_submit():
+    if form.validate_on_submit():
         topic.create_post(form.body.data, current_user.id)
         return redirect(url_for("routes.topic_page", topic_id=topic.id))
     return render_template("posts-create.html", form=form, topic=topic, current_user=current_user)


### PR DESCRIPTION
While working on error handling for topic routes (https://github.com/fenya123/forum123/issues/55) we used a walrus operator := to check that there is no such topic in database.
After that we got this code:

```
if not (topic := session.query(Topic).filter_by(id=topic_id).first()):
    return ...
if topic and form.validate_on_submit():
    ...
```

Actulally there is no need to check for topic presence in the second if-statement, since if there is no topic, the first if-statement will just exit the function at the return statement.

So in the scope of this task we need to remove a check for topic presence in the second if statement.