### PR TITLE
87: Move get_current_user function to users package

### DIFF
--- a/src/routes.py
+++ b/src/routes.py
@@ -5,29 +5,19 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from flask import Blueprint
-from flask import redirect, render_template, request, url_for
+from flask import redirect, render_template, url_for
 
 from src.database import session_var
 from src.forms import PostForm, TopicForm
 from src.models import Topic
-from src.users.models import User, UserSession
+from src.users.models import User
+from src.users.utils import get_current_user
 
 if TYPE_CHECKING:
     from werkzeug.wrappers.response import Response
 
 
 bp = Blueprint("routes", __name__)
-
-
-def get_current_user() -> User | None:
-    """Use this function to get current user."""
-    user_session = None
-    if session_id := request.cookies.get("session_id"):
-        user_session = UserSession.get_user_session_by_session_id(session_id)
-
-    if user_session is not None:
-        return user_session.user
-    return None
 
 
 @bp.route("/check-unit-tests", methods=["POST"])

--- a/src/users/utils.py
+++ b/src/users/utils.py
@@ -1,0 +1,23 @@
+"""Some utilities for working with users."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from flask import request
+
+from src.users.models import UserSession
+
+if TYPE_CHECKING:
+    from src.users.models import User
+
+
+def get_current_user() -> User | None:
+    """Use this function to get current user."""
+    user_session = None
+    if session_id := request.cookies.get("session_id"):
+        user_session = UserSession.get_user_session_by_session_id(session_id)
+
+    if user_session is not None:
+        return user_session.user
+    return None


### PR DESCRIPTION
While working on separating user-related functionality (#79) we forgot to move `get_current_user` function to the `src/users` package.

So in the scope of this ticket we need to move `get_current_user` to `src/users/utils.py`.