### PR TITLE
96: Fix app path in gunicorn prod config

### DIFF
--- a/envs/prod/gunicorn/config.py
+++ b/envs/prod/gunicorn/config.py
@@ -6,4 +6,4 @@ bind = "0.0.0.0:5000"
 
 errorlog = "-"  # here "-" means stdout
 
-wsgi_app = "src:app"
+wsgi_app = "src.app:app"


### PR DESCRIPTION
When we moved our flask application from `src/__init__.py` to `src/app.py` (#83), we forgot to update path to the application in `envs/prod/gunicorn/config.py`. This caused a deployment failure for the app container.

So in the scope of this ticket we need to change path to the application in `envs/prod/gunicorn/config.py`

from: `wsgi_app = "src:app"`

to: `wsgi_app = "src.app:app"`.