### PR TITLE
99: Add rest endpoint to get user

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -6,6 +6,8 @@ strict = True
 
 plugins = sqlalchemy.ext.mypy.plugin
 
+[mypy-flask_restx]
+ignore_missing_imports = True
 
 [mypy-flask_wtf]
 ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 
 alembic[tz]==1.9.1
 flask==2.2.2
+flask-restx==1.1.0
 flask-WTF==1.0.1
 python-dotenv==0.21.0
 psycopg2-binary==2.9.5

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,0 +1,1 @@
+"""'api' package's initialization module."""

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -1,0 +1,12 @@
+"""'api' package's routes module."""
+
+from flask import Blueprint
+from flask_restx import Api
+
+import src.api.users.routes
+
+
+bp = Blueprint("api", __name__)
+
+api = Api(bp, prefix="/api")
+api.add_namespace(src.api.users.routes.ns)

--- a/src/api/users/__init__.py
+++ b/src/api/users/__init__.py
@@ -1,0 +1,1 @@
+"""'users' api package's initialization module."""

--- a/src/api/users/routes.py
+++ b/src/api/users/routes.py
@@ -1,0 +1,26 @@
+"""users endpoint module."""
+
+from typing import Any
+
+from flask import abort
+from flask_restx import Namespace, Resource
+
+from src.users.models import User
+
+
+ns = Namespace("users", path="/users")
+
+
+@ns.route("/<int:user_id>")
+class UserInfo(Resource):  # type: ignore
+    """Get user's id and name."""
+
+    @staticmethod
+    def get(user_id: int) -> dict[str, Any] | None:
+        """Get user's id and name."""
+        if not (user := User.get_user_by_id(user_id)):
+            return abort(404, "Could not find a user with id provided.")
+        return {
+            "id": user.id,
+            "name": user.username,
+        }

--- a/src/app.py
+++ b/src/app.py
@@ -3,17 +3,20 @@
 from flask import Flask
 from werkzeug.middleware.proxy_fix import ProxyFix
 
+import src.api.routes
 import src.index.routes
 import src.posts.routes
 import src.topics.routes
 import src.users.routes
 from src.config import Config
 
+
 app = Flask(__name__)
 app.register_blueprint(src.users.routes.bp)
 app.register_blueprint(src.topics.routes.bp)
 app.register_blueprint(src.index.routes.bp)
 app.register_blueprint(src.posts.routes.bp)
+app.register_blueprint(src.api.routes.bp)
 app.config.from_object(Config)
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -17,6 +17,8 @@ class Config():  # pylint: disable=too-few-public-methods
     PROXIES_X_PREFIX = int(os.environ.get("PROXIES_X_PREFIX", 0))
     PROXIES_X_PROTO = int(os.environ.get("PROXIES_X_PROTO", 0))
 
+    RESTX_ERROR_404_HELP = False
+
     SECRET_KEY = os.environ.get("SECRET_KEY", "bob")
 
     # next will be listed options derived from the options above

--- a/src/users/models.py
+++ b/src/users/models.py
@@ -64,6 +64,13 @@ class User(Base):
             return user_to_fetch
         return None
 
+    @staticmethod
+    def get_user_by_id(user_id: int) -> User | None:
+        """Use this method to fetch a user from users table with a specific id."""
+        session = session_var.get()
+        user_to_fetch: User | None = session.query(User).filter_by(id=user_id).first()
+        return user_to_fetch
+
 
 class UserSession(Base):
     """A model class for user_session table."""

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -28,6 +28,9 @@ proto
 # linter
 pylint
 
+# flask package
+restx
+
 # sessionmaker
 sessionmaker
 


### PR DESCRIPTION
We are going to add REST API interface to our forum, and we decided to begin with creating endpoints without authentication. It won't be secure but it will make development process easier. We will add authentication to these endpoints in the future.

First REST API endpoints we want to implement are probably the easiest one. We need an endpoint which will return the info about particular user. In our application whole info is only id and username.

So in the scope of this task we need to create an endpoint `GET /api/users/42` which will return user info in json format.

All REST API code should be in `src/api` and should have "package by layered feature" structure. All REST API endpoints should start with `/api`. To make rest api's on flask we're going to use [flask-restx](https://flask-restx.readthedocs.io/en/latest/) library.