### PR TITLE
101: Add REST endpoint to get topic

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -3,6 +3,7 @@
 from flask import Blueprint
 from flask_restx import Api
 
+import src.api.topics.routes
 import src.api.users.routes
 
 
@@ -10,3 +11,4 @@ bp = Blueprint("api", __name__)
 
 api = Api(bp, prefix="/api")
 api.add_namespace(src.api.users.routes.ns)
+api.add_namespace(src.api.topics.routes.ns)

--- a/src/api/topics/__init__.py
+++ b/src/api/topics/__init__.py
@@ -1,0 +1,1 @@
+"""'topics' api package's initialization module."""

--- a/src/api/topics/routes.py
+++ b/src/api/topics/routes.py
@@ -1,0 +1,28 @@
+"""topics endpoint module."""
+
+from typing import Any
+
+from flask import abort
+from flask_restx import Namespace, Resource
+
+from src.topics.models import Topic
+
+
+ns = Namespace("topics", path="/topics")
+
+
+@ns.route("/<int:topic_id>")
+class TopicInfo(Resource):  # type: ignore
+    """Get a topic's information.."""
+
+    @staticmethod
+    def get(topic_id: int) -> dict[str, Any] | None:
+        """Get a topic's information."""
+        if not (topic := Topic.get(topic_id)):
+            return abort(404, "Could not find a topic with id provided.")
+        return {
+            "author_id": topic.author_id,
+            "created_at": str(topic.created_at),
+            "description": topic.description,
+            "title": topic.title,
+        }


### PR DESCRIPTION
We are going to add REST API interface to our forum, and we decided to begin with creating endpoints without authentication. It won't be secure but it will make development process easier. We will add authentication to these endpoints in the future.

We need to add an endpoint which will return the info about particular topic. It will be `author_id`, `created_at`, `description`, and `title`.

So in the scope of this task we need to create an endpoint which will return topic info in json format, or 404 if topic was not found.