### PR TITLE
102: Add REST endpoint to get post

### DIFF
--- a/src/api/posts/__init__.py
+++ b/src/api/posts/__init__.py
@@ -1,0 +1,1 @@
+"""'posts' api package's initialization module."""

--- a/src/api/posts/routes.py
+++ b/src/api/posts/routes.py
@@ -1,0 +1,28 @@
+"""posts endpoint module."""
+
+from typing import Any
+
+from flask import abort
+from flask_restx import Namespace, Resource
+
+from src.posts.models import Post
+
+
+ns = Namespace("posts", path="/posts")
+
+
+@ns.route("/<int:post_id>")
+class PostInfo(Resource):  # type: ignore
+    """Get a post's information."""
+
+    @staticmethod
+    def get(post_id: int) -> dict[str, Any] | None:
+        """Get a post's information."""
+        if not (post := Post.get_post_by_id(post_id)):
+            return abort(404, "Could not find a post with id provided.")
+        return {
+            "author_id": post.id,
+            "created_at": str(post.created_at),
+            "body": post.body,
+            "topic_id": post.topic_id,
+        }

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -3,6 +3,7 @@
 from flask import Blueprint
 from flask_restx import Api
 
+import src.api.posts.routes
 import src.api.topics.routes
 import src.api.users.routes
 
@@ -12,3 +13,4 @@ bp = Blueprint("api", __name__)
 api = Api(bp, prefix="/api")
 api.add_namespace(src.api.users.routes.ns)
 api.add_namespace(src.api.topics.routes.ns)
+api.add_namespace(src.api.posts.routes.ns)

--- a/src/posts/models.py
+++ b/src/posts/models.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import Column, DateTime, ForeignKey, func, Integer, String
 from sqlalchemy.orm import relationship
 
-from src.database import Base
+from src.database import Base, session_var
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -25,3 +25,9 @@ class Post(Base):  # pylint: disable=too-few-public-methods
     body: str = Column(String(123), nullable=False)
     topic_id: int = Column(Integer, ForeignKey("topics.id"), nullable=False)
     author: User = relationship("User", uselist=False)
+
+    @staticmethod
+    def get_post_by_id(topic_id: int) -> Post | None:
+        """Use this method to get a post with a certain id."""
+        session = session_var.get()
+        return session.query(Post).filter_by(id=topic_id).first()


### PR DESCRIPTION
We are going to add REST API interface to our forum, and we decided to begin with creating endpoints without authentication. It won't be secure but it will make development process easier. We will add authentication to these endpoints in the future.

We need to add an endpoint which will return the info about particular post. It will be `author_id`, `created_at`, `body`, and `topic_id`.

So in the scope of this task we need to create an endpoint which will return post info in json format, or 404 if post was not found.
