### PR TITLE
107: Add REST endpoint to get list of topics

### DIFF
--- a/src/api/topics/routes.py
+++ b/src/api/topics/routes.py
@@ -3,12 +3,34 @@
 from typing import Any
 
 from flask import abort
-from flask_restx import Namespace, Resource
+from flask_restx import Namespace, reqparse, Resource
 
+from src.api.topics.utils import parse_order_by
 from src.topics.models import Topic
 
 
 ns = Namespace("topics", path="/topics")
+
+parser = reqparse.RequestParser()
+
+
+@ns.route("")
+class TopicList(Resource):  # type: ignore
+    """Get a sorted list of all topics."""
+
+    @staticmethod
+    def get() -> list[dict[str, Any]] | None:
+        """Get a sorted list of all topics."""
+        parser.add_argument("order_by", type=parse_order_by, help="get a sorted list of topics")
+        sorting_parameters = parser.parse_args()
+        topics = Topic.get_topics(sorting_parameters["order_by"])
+        return [{
+            "id": topic.id,
+            "author_id": topic.author_id,
+            "created_at": str(topic.created_at),
+            "description": topic.description,
+            "title": topic.title,
+        } for topic in topics]
 
 
 @ns.route("/<int:topic_id>")

--- a/src/api/topics/utils.py
+++ b/src/api/topics/utils.py
@@ -1,0 +1,21 @@
+"""Some utilities for api.topics."""
+
+
+from flask import abort
+
+from src.topics.models import Topic
+
+
+def parse_order_by(value: str) -> dict[str, str] | None:  # noqa: CFQ004  # pylint: disable=duplicate-code
+    """Parse arguments provided."""
+    if not value:
+        return abort(400, "empty argument value is not allowed")
+
+    try:
+        parameter, order = value.split(",")
+    except ValueError:
+        return abort(400, "failed parsing parameters provided")
+
+    if parameter not in Topic.SORTING_FIELDS or order not in Topic.SORTING_ORDER:
+        return abort(400, "provided value is not allowed")
+    return {"field": parameter, "order": order}


### PR DESCRIPTION
We are going to add REST API interface to our forum, and we decided to begin with creating endpoints without authentication. It won't be secure but it will make development process  easier. We will add authentication to these endpoints in the future.

We need an endpoint which will return the list of topics with abitily to sort results. Sorting will be specified via `order_by` query parameter. `order_by` should accept a string with two words separated by comma. First word is the name of the sorting field (only `created_at`, `title` are acceptable for now). Second word is the sorting direction (`asc` or `desc`). If there were no `order_by` provided, then return topics ordered by `created_at` ascending.

**Request example:**
```
GET /api/topics?order_by=created_at,desc
```

**Response example:**
```
[
    {
        "id": 12,
        "authorId": 21,
        "createdAt": "2023-04-08 19:51:43.986889".
        "description": "Some topic description",
        "title": "Some topic title"
    },
    {
        "id": 10,
        "authorId": 1,
        "createdAt": "2023-04-08 19:51:37.503064",
        "description": "Another topic description",
        "title": "Another topic title"
    }
]
```

So in the scope of this task we need to create an endpoint `GET /api/topics` which will return list of topics info in json format, or 400 if request is not valid.