### PR TITLE
109: Remove useless code from get_users

### DIFF
--- a/src/api/users/routes.py
+++ b/src/api/users/routes.py
@@ -23,8 +23,7 @@ class UserList(Resource):  # type: ignore
         """Get a list of all users, sorted if needed."""
         parser.add_argument("order_by", type=parse_order_by, help="get a sorted list of users")
         sorting_parameters = parser.parse_args()
-        if not (users := User.get_users(sorting_parameters["order_by"])):
-            return []
+        users = User.get_users(sorting_parameters["order_by"])
         return [{"id": user.id, "username": user.username} for user in users]
 
 

--- a/src/users/models.py
+++ b/src/users/models.py
@@ -58,8 +58,6 @@ class User(Base):
         """Use this method to get all users from users table."""
         sorting = {"field": "id", "order": "asc"} if sorting is None else sorting
         session = session_var.get()
-        if not sorting:
-            return session.query(User).all()
         if sorting["order"] == "desc":
             return session.query(User).order_by(desc(sorting["field"])).all()
         return session.query(User).order_by(sorting["field"]).all()


### PR DESCRIPTION
While working on adding REST endpoint for getting list of users (#105), we missed some cases where actual code isn't already needed.

1. Unused if-statement in `src/api/users/models.py`.
    ```python
    def get_users(sorting: dict[str, str] | None = None) -> list[User]:
        ...
        if not sorting:
            return session.query(User).all()
        ...
    ```

    We don't need it because our sorting argument will never be None, because of this:
    ```python
    def get_users(sorting: dict[str, str] | None = None) -> list[User]:
        sorting = {"field": "id", "order": "asc"} if sorting is None else sorting
    ```

2. Unused if-statement in `src/api/users/routes.py`.
    ```python
        def get() -> list[dict[str, Any]] | None:
            ...
            if not (users := User.get_users(sorting_parameters["order_by"])):
                return []
            ...
    ```
    
    We don't need it because if `User.get_users()` will return and empty collection we can use it in our list-comprehension anyway, and it will generate an empty list.
    ```python
        def get() -> list[dict[str, Any]] | None:
            ...
            if not (users := User.get_users(sorting_parameters["order_by"])):
                return []
            return [{"id": user.id, "username": user.username} for user in users]
    ```

So in the scope of this task we need to remove useless code which remained after merging of #105.