### PR TITLE
112: Add REST endpoint to get lst of posts

### DIFF
--- a/src/api/posts/routes.py
+++ b/src/api/posts/routes.py
@@ -3,12 +3,38 @@
 from typing import Any
 
 from flask import abort
-from flask_restx import Namespace, Resource
+from flask_restx import Namespace, reqparse, Resource
 
+from src.api.posts.utils import parse_order_by
+from src.api.topics.routes import ns as topics_ns
 from src.posts.models import Post
+from src.topics.models import Topic
 
 
 ns = Namespace("posts", path="/posts")
+
+parser = reqparse.RequestParser()
+
+
+@topics_ns.route("/<int:topic_id>/posts")
+class PostsList(Resource):  # type: ignore
+    """Get a list of posts of a certain topic."""
+
+    @staticmethod
+    def get(topic_id: int) -> list[dict[str, Any]] | None:
+        """Get a list of posts of a certain topic."""
+        parser.add_argument("order_by", type=parse_order_by, help="get a list of posts of a topic")
+        sorting_parameters = parser.parse_args()
+        if not Topic.get(topic_id):
+            return abort(404, "topic does not exist")
+        posts = Post.get_posts_list(topic_id, sorting_parameters["order_by"])
+        return [{
+            "id": post.id,
+            "author_id": post.author_id,
+            "created_at": str(post.created_at),
+            "body": post.body,
+            "topic_id": post.topic_id,
+        } for post in posts]
 
 
 @ns.route("/<int:post_id>")

--- a/src/api/posts/utils.py
+++ b/src/api/posts/utils.py
@@ -1,0 +1,20 @@
+"""Some utilities for api.posts."""
+
+from flask import abort
+
+from src.posts.models import Post
+
+
+def parse_order_by(value: str) -> dict[str, str] | None:  # noqa: CFQ004  # pylint: disable=duplicate-code
+    """Parse arguments provided."""
+    if not value:
+        return abort(400, "empty argument value is not allowed")
+
+    try:
+        parameter, order = value.split(",")
+    except ValueError:
+        return abort(400, "failed parsing parameters provided")
+
+    if parameter not in Post.SORTING_FIELDS or order not in Post.SORTING_ORDER:
+        return abort(400, "provided value is not allowed")
+    return {"field": parameter, "order": order}

--- a/src/posts/models.py
+++ b/src/posts/models.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Final, TYPE_CHECKING
 
-from sqlalchemy import Column, DateTime, ForeignKey, func, Integer, String
+from sqlalchemy import Column, DateTime, desc, ForeignKey, func, Integer, String
 from sqlalchemy.orm import relationship
 
 from src.database import Base, session_var
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from src.users.models import User
 
 
-class Post(Base):  # pylint: disable=too-few-public-methods
+class Post(Base):
     """A model class for posts table."""
 
     __tablename__ = "posts"
@@ -26,8 +26,20 @@ class Post(Base):  # pylint: disable=too-few-public-methods
     topic_id: int = Column(Integer, ForeignKey("topics.id"), nullable=False)
     author: User = relationship("User", uselist=False)
 
+    SORTING_FIELDS: Final = ("created_at")
+    SORTING_ORDER: Final = ("asc", "desc")
+
     @staticmethod
     def get_post_by_id(post_id: int) -> Post | None:
         """Use this method to get a post with a certain id."""
         session = session_var.get()
         return session.query(Post).filter_by(id=post_id).first()
+
+    @staticmethod
+    def get_posts_list(topic_id: int, sorting: dict[str, str] | None = None) -> list[Post]:
+        """Use this method to get a list of posts of a certain topic."""
+        sorting = {"field": "created_at", "order": "asc"} if sorting is None else sorting
+        session = session_var.get()
+        if sorting["order"] == "desc":
+            return session.query(Post).filter_by(topic_id=topic_id).order_by(desc(sorting["field"])).all()
+        return session.query(Post).filter_by(topic_id=topic_id).order_by(sorting["field"]).all()


### PR DESCRIPTION
We are going to add REST API interface to our forum, and we decided to begin with creating endpoints without authentication. It won't be secure but it will make development process  easier. We will add authentication to these endpoints in the future.

We need an endpoint which will return the list of posts from particular topic with abitily to sort results. Sorting will be specified via `order_by` query parameter. `order_by` should accept a string with two words separated by comma. First word is the name of the sorting field (only `created_at` is acceptable for now). Second word is the sorting direction (`asc` or `desc`). If there were no `order_by` provided, then return posts ordered by `created_at` ascending.

**Request example:**
```
GET /api/topics/42/posts?order_by=created_at,desc
```

**Response example:**
```
[
    {
        "id": 12,
        "author_id": 21,
        "created_at": "2023-04-08 19:51:43.986889".
        "body": "Some post body",
        "topic_id": 42
    },
    {
        "id": 10,
        "author_id": 1,
        "created_at": "2023-04-08 19:51:37.503064",
        "body": "Another post body"
        "topic_id": 42
    }
]
```

So in the scope of this task we need to create an endpoint `GET /api/topics/42/posts` which will return list of posts info in json format, or 400 if request is not valid, or 404 if topic doesn't exist.