### PR TITLE
114: Fix paramenter name in get_post_by_id

### DIFF
--- a/src/posts/models.py
+++ b/src/posts/models.py
@@ -27,7 +27,7 @@ class Post(Base):  # pylint: disable=too-few-public-methods
     author: User = relationship("User", uselist=False)
 
     @staticmethod
-    def get_post_by_id(topic_id: int) -> Post | None:
+    def get_post_by_id(post_id: int) -> Post | None:
         """Use this method to get a post with a certain id."""
         session = session_var.get()
-        return session.query(Post).filter_by(id=topic_id).first()
+        return session.query(Post).filter_by(id=post_id).first()


### PR DESCRIPTION
While working on add REST endpoint to get post (#102), we made a mistake and name parameter for `get_post_by_id` as `topic_id` instead of `post_id`:
```python
@staticmethod
def get_post_by_id(topic_id: int) -> Post | None:
    ...
```

So in the scope of this task we need to rename this parameter `topic_id` -> `post_id`.