### PR TITLE
98: Add REST endpoint for authentication

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ alembic[tz]==1.9.1
 flask==2.2.2
 flask-restx==1.1.0
 flask-WTF==1.0.1
+pyjwt==2.6.0
 python-dotenv==0.21.0
 psycopg2-binary==2.9.5
 sqlalchemy==1.4.46

--- a/src/api/auth/__init__.py
+++ b/src/api/auth/__init__.py
@@ -1,0 +1,1 @@
+"""'auth' api package's initialization module."""

--- a/src/api/auth/routes.py
+++ b/src/api/auth/routes.py
@@ -1,0 +1,28 @@
+"""auth endpoint module."""
+
+import jwt
+from flask import abort
+from flask_restx import Namespace, reqparse, Resource
+
+from src.config import Config
+from src.users.models import User
+
+
+ns = Namespace("auth", path="/auth")
+
+parser = reqparse.RequestParser()
+
+
+@ns.route("")
+class AuthEndpoint(Resource):  # type: ignore
+    """API authentication class."""
+
+    @staticmethod
+    def post() -> str | None:
+        """Authenticate credentials and return JWT token."""
+        parser.add_argument("username", required=True, type=str)
+        parser.add_argument("password", required=True, type=str)
+        credentials = parser.parse_args()
+        if not (user := User.get_user_by_credentials(credentials["username"], credentials["password"])):
+            return abort(400, "couldn't find user with credentials provided")
+        return jwt.encode({"user_id": user.id}, Config.SECRET_KEY, algorithm="HS256")

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -3,6 +3,7 @@
 from flask import Blueprint
 from flask_restx import Api
 
+import src.api.auth.routes
 import src.api.posts.routes
 import src.api.topics.routes
 import src.api.users.routes
@@ -14,3 +15,4 @@ api = Api(bp, prefix="/api")
 api.add_namespace(src.api.users.routes.ns)
 api.add_namespace(src.api.topics.routes.ns)
 api.add_namespace(src.api.posts.routes.ns)
+api.add_namespace(src.api.auth.routes.ns)


### PR DESCRIPTION
In order to restrict access to the REST API endpoints we need to add REST authentication. We want to implement simplified version of authentication via JWT tokens. JWT token should contain user id and should be encoded via "HS256" algorithm. Interface of the endpoint should be:

**Request:**

`POST /api/auth`

```javascript
{
    "username": "John",  // required string field
    "password": "qwerty",  // required string field
}
```

**Response:**

```javascript
{
    "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDJ9.YKVpm2zdxup0_ts81Ft4USo-AUMKXBCTfgXtNFbRLlg",  // required string field
}
```

All REST API related code should be in `src/api` package. All routes should have prefix `/api`. 

In the scope of this task we need to add REST authentication endpoint which will accept user credentials and return JWT token for this user.

### Steps to do

Add endpoint which takes POST request with JSON body with two fields `"username"` and `"password"`. Both fields should be required. To parse request body we will use [reqparse](https://flask-restx.readthedocs.io/en/latest/parsing.html#request-parsing) from [flask-restx](https://flask-restx.readthedocs.io/en/latest/index.html).

This endpoint should parse request body and validate inputs, if some of them are wrong - return 400 error.
If all inputs are correct, then it should generate JWT token for that user and return it.

To generate JWT token we will use [pyjwt](https://pyjwt.readthedocs.io/en/latest/) library. The body of the token will contain only id of the authenticated user: `"user_id" = 42`, and should be cryptograpically [signed](https://pyjwt.readthedocs.io/en/latest/algorithms.html#specifying-an-algorithm) by `HS256` algorithm with our secret key from `Config().SECRET_KEY`