### PR TITLE
118: Add authorization to REST endpoints

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -18,6 +18,7 @@ enable-extensions =
 ignore =
     ANN101,  # Missing type annotation for self in method
     ANN102,  # Missing type annotation for cls in class method
+    CFQ004,  # Exceeding maximum allowed amount of returns (3)
     E902,  # TokenError: EOF in multi-line statement
     S101,  # Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
     W503,  # Line break occurred before a binary operator.

--- a/src/api/auth/utils.py
+++ b/src/api/auth/utils.py
@@ -1,0 +1,36 @@
+"""Some utilities for api package."""
+
+import functools
+from typing import Any
+
+import jwt
+from flask import abort
+from flask_restx import reqparse
+from jwt import InvalidTokenError
+
+from src.config import Config
+from src.users.models import User
+
+
+parser = reqparse.RequestParser()
+parser.add_argument("Authorization", required=True, location="headers")
+
+
+def authorized_access(function_to_wrap: Any) -> Any:
+    """Parse, validate and decode JWT authorization token."""
+    @functools.wraps(function_to_wrap)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        parsed_arguments = parser.parse_args()
+        scheme, _, token = parsed_arguments["Authorization"].partition(" ")
+        if scheme != "Bearer" or token == "":  # pylint: disable=compare-to-empty-string
+            return abort(401, "invalid token")
+
+        try:
+            decoded_token = jwt.decode(token, Config.SECRET_KEY, algorithms=["HS256"])
+        except InvalidTokenError:
+            return abort(401, "invalid token")
+
+        if not User.get_user_by_id(decoded_token["user_id"]):
+            return abort(403, "user not found")
+        return function_to_wrap(*args, **kwargs)
+    return wrapper

--- a/src/api/posts/routes.py
+++ b/src/api/posts/routes.py
@@ -5,6 +5,7 @@ from typing import Any
 from flask import abort
 from flask_restx import Namespace, reqparse, Resource
 
+from src.api.auth.utils import authorized_access
 from src.api.posts.utils import parse_order_by
 from src.api.topics.routes import ns as topics_ns
 from src.posts.models import Post
@@ -21,6 +22,7 @@ class PostsList(Resource):  # type: ignore
     """Get a list of posts of a certain topic."""
 
     @staticmethod
+    @authorized_access
     def get(topic_id: int) -> list[dict[str, Any]] | None:
         """Get a list of posts of a certain topic."""
         parser.add_argument("order_by", type=parse_order_by, help="get a list of posts of a topic")
@@ -42,6 +44,7 @@ class PostInfo(Resource):  # type: ignore
     """Get a post's information."""
 
     @staticmethod
+    @authorized_access
     def get(post_id: int) -> dict[str, Any] | None:
         """Get a post's information."""
         if not (post := Post.get_post_by_id(post_id)):

--- a/src/api/topics/routes.py
+++ b/src/api/topics/routes.py
@@ -5,6 +5,7 @@ from typing import Any
 from flask import abort
 from flask_restx import Namespace, reqparse, Resource
 
+from src.api.auth.utils import authorized_access
 from src.api.topics.utils import parse_order_by
 from src.topics.models import Topic
 
@@ -19,6 +20,7 @@ class TopicList(Resource):  # type: ignore
     """Get a sorted list of all topics."""
 
     @staticmethod
+    @authorized_access
     def get() -> list[dict[str, Any]] | None:
         """Get a sorted list of all topics."""
         parser.add_argument("order_by", type=parse_order_by, help="get a sorted list of topics")
@@ -38,6 +40,7 @@ class TopicInfo(Resource):  # type: ignore
     """Get a topic's information.."""
 
     @staticmethod
+    @authorized_access
     def get(topic_id: int) -> dict[str, Any] | None:
         """Get a topic's information."""
         if not (topic := Topic.get(topic_id)):

--- a/src/api/users/routes.py
+++ b/src/api/users/routes.py
@@ -5,6 +5,7 @@ from typing import Any
 from flask import abort
 from flask_restx import Namespace, reqparse, Resource
 
+from src.api.auth.utils import authorized_access
 from src.api.users.utils import parse_order_by
 from src.users.models import User
 
@@ -19,6 +20,7 @@ class UserList(Resource):  # type: ignore
     """Get a list of all users, sorted if needed."""
 
     @staticmethod
+    @authorized_access
     def get() -> list[dict[str, Any]] | None:
         """Get a list of all users, sorted if needed."""
         parser.add_argument("order_by", type=parse_order_by, help="get a sorted list of users")
@@ -32,6 +34,7 @@ class UserInfo(Resource):  # type: ignore
     """Get user's id and name."""
 
     @staticmethod
+    @authorized_access
     def get(user_id: int) -> dict[str, Any] | None:
         """Get user's id and name."""
         if not (user := User.get_user_by_id(user_id)):


### PR DESCRIPTION
fter we've added REST endpoint for authentication (#98), we can add authorization to our existing endpoints.

In order to do authorization (check user access rights) each REST API endpoint should accept an "Authorization" [header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization). With "Bearer" [scheme](https://github.com/fenya123/forum123/issues/118#issuecomment-1512064667) and our JWT token.

Each endpoint should parse JWT token from Authorization header and check if there is such user in our database.  If header is not provided return 401. If user is not found return 403.

Since this authorization check has to be in every endpoint, we need to move this logic into separate function to avoid duplication.

So in the scope of this task we need to add JWT authorization to every REST endpoint.