### PR TITLE
122: Fix mismerged code for authorized_access decorator

### DIFF
--- a/src/api/auth/utils.py
+++ b/src/api/auth/utils.py
@@ -26,7 +26,7 @@ parser = reqparse.RequestParser()
 
 def parse_token_data(header: str) -> dict[str, int]:
     """Parse and validate JWT authorization token from Authorization request header."""
-    scheme, token = header.split(" ")
+    scheme, _, token = header.partition(" ")
     if scheme != "Bearer" or token == "":  # pylint: disable=compare-to-empty-string
         return abort(401, "invalid token")
     try:

--- a/src/api/posts/routes.py
+++ b/src/api/posts/routes.py
@@ -22,7 +22,7 @@ class PostsList(Resource):  # type: ignore
     """Get a list of posts of a certain topic."""
 
     @staticmethod
-    @authorized_access(provide_user=True)
+    @authorized_access()
     def get(topic_id: int) -> list[dict[str, Any]] | None:
         """Get a list of posts of a certain topic."""
         parser.add_argument("order_by", type=parse_order_by, help="get a list of posts of a topic")


### PR DESCRIPTION
While working on adding REST endpoint for creating a new topic (#116), we have merged some functionality unintentionally and we need to fix these two things:

1. Remove unused `provide_user=True` argument from `@authorized_access` decorator for `PostsList.get()` route.
2. Use `.partition()` instead of `.split()` in `parse_token_data`. This was changed by accident during separating out token parsing logic.

So in the scope of this ticket we need to apply somefixes caused by careless merging.