### PR TITLE
124: Add filtering to get topics REST endpoint

### DIFF
--- a/src/api/topics/routes.py
+++ b/src/api/topics/routes.py
@@ -8,7 +8,7 @@ from flask import abort
 from flask_restx import Namespace, reqparse, Resource
 
 from src.api.auth.utils import authorized_access
-from src.api.topics.utils import parse_order_by
+from src.api.topics.utils import parse_author_id, parse_datetime, parse_order_by
 from src.topics.models import Topic
 
 if TYPE_CHECKING:
@@ -27,9 +27,17 @@ class TopicList(Resource):  # type: ignore
     @authorized_access()
     def get() -> list[dict[str, Any]] | None:
         """Get a sorted list of all topics."""
-        parser.add_argument("order_by", type=parse_order_by, help="get a sorted list of topics")
-        sorting_parameters = parser.parse_args()
-        topics = Topic.get_topics(sorting_parameters["order_by"])
+        parser.add_argument("order_by", type=parse_order_by)
+        parser.add_argument("author_id", type=parse_author_id, action="append")
+        parser.add_argument("created_after", type=parse_datetime)
+        parser.add_argument("created_before", type=parse_datetime)
+        parsed_args = parser.parse_args()
+        topics = Topic.get_topics(
+            sorting=parsed_args.get("order_by"),
+            author_ids=parsed_args.get("author_ids"),
+            created_before=parsed_args.get("created_before"),
+            created_after=parsed_args.get("created_after"),
+        )
         return [{
             "id": topic.id,
             "author_id": topic.author_id,

--- a/src/api/topics/utils.py
+++ b/src/api/topics/utils.py
@@ -1,12 +1,13 @@
 """Some utilities for api.topics."""
 
+from datetime import datetime
 
 from flask import abort
 
 from src.topics.models import Topic
 
 
-def parse_order_by(value: str) -> dict[str, str] | None:  # noqa: CFQ004  # pylint: disable=duplicate-code
+def parse_order_by(value: str) -> dict[str, str] | None:  # pylint: disable=duplicate-code
     """Parse arguments provided."""
     if not value:
         return abort(400, "empty argument value is not allowed")
@@ -19,3 +20,25 @@ def parse_order_by(value: str) -> dict[str, str] | None:  # noqa: CFQ004  # pyli
     if parameter not in Topic.SORTING_FIELDS or order not in Topic.SORTING_ORDER:
         return abort(400, "provided value is not allowed")
     return {"field": parameter, "order": order}
+
+
+def parse_author_id(value: str) -> int | None:
+    """Parse author_id query parameter."""
+    if not value:
+        return abort(400, "empty argument value is not allowed")
+    try:
+        int(value)
+    except ValueError:
+        return abort(400, "author id must be an integer")
+    return int(value)
+
+
+def parse_datetime(value: str) -> datetime | None:
+    """Parse dates as strings and return datetime objects."""
+    if not value:
+        return abort(400, "empty argument value is not allowed")
+    try:
+        parsed_datetime = datetime.strptime(value, "%Y-%m-%d %H:%M:%S.%f")
+    except ValueError:
+        return abort(400, "invalid datetime string")
+    return parsed_datetime  # noqa: R504

--- a/src/topics/models.py
+++ b/src/topics/models.py
@@ -49,13 +49,23 @@ class Topic(Base):
         return new_post
 
     @staticmethod
-    def get_topics(sorting: dict[str, str] | None = None) -> list[Topic]:
+    def get_topics(sorting: dict[str, str] | None = None,
+                   author_ids: list[int] | None = None,
+                   created_before: datetime | None = None,
+                   created_after: datetime | None = None) -> list[Topic]:
         """Use this method to get all topics from topics table."""
         sorting = {"field": "created_at", "order": "asc"} if sorting is None else sorting
         session = session_var.get()
+        topics_query = session.query(Topic)
+        if author_ids:
+            topics_query = topics_query.filter(Topic.author_id.in_(author_ids))
+        if created_after:
+            topics_query = topics_query.filter(Topic.created_at > created_after)
+        if created_before:
+            topics_query = topics_query.filter(Topic.created_at < created_before)
         if sorting["order"] == "desc":
-            return session.query(Topic).order_by(desc(sorting["field"])).all()
-        return session.query(Topic).order_by(sorting["field"]).all()
+            return topics_query.order_by(desc(sorting["field"])).all()
+        return topics_query.order_by(sorting["field"]).all()
 
     @staticmethod
     def get(topic_id: int) -> Topic | None:


### PR DESCRIPTION
We need to add filtration to the `get_topics` REST route. Filter should be possible by the following attributes: `author_id`, `created_before`, `created_after`.

**Request example**
```http
GET /topics?author_id=42&author_id=24&author_id=18
```

**Response example**
```python
[
    # topics with author_id 42 or 24 or 18
]
```

We suppose that all datetime related query params will be sent in UTC timezone in the following format:
```text
'2023-04-24 05:10:20.782336'
```

**Request example**

```http
GET /topics?created_after=2023-04-24 04:10:20.782336&created_before=2023-04-24 05:10:20.782336
```

So in the scope of this task we need to add filtration for `get_topics` route.