### PR TITLE
130: Fix run tests in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,8 @@ Linters order above is the preffered way to run and fix them one by one.
 
 1. Open terminal
 2. Run services using `docker-compose -f envs/test/docker-compose.yml up --detach` command.
-3. Type `pytest` command in terminal.
-   If you want to check coverage, run `pytest --cov=src`. This command also creates `htmlcov/index.html` file,
-   which you can open in your browser and look at the html report.
+3. Type `POSTGRES_PORT=5433 pytest` command in terminal.
+   If you want to check coverage, run `POSTGRES_PORT=5433 pytest --cov=src`. This command also creates `htmlcov/index.html` file,
 
 
 ### Working with migrations


### PR DESCRIPTION
While working on adding unit-testing layout (#58), we added wrong command for running test in `README.md` file.

Command used in "Run tests" section doesn't connect our testing application to the testing database.

In the scope of this ticket we need to add `POSTGRES_PORT=5433` to the beginning of "Run pylint" command in `README.md` like that:
```bash
POSTGRES_PORT=5433 pytest --cov=src
```