### PR TITLE
129: Adjust coverage to check only rest code

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,32 @@
 [run]
 branch = True
 
+source =
+    src
+
+omit =
+    # the files listed below contains code related to ssr
+    # we don't want to cover this code by unit-tests
+    # we want to cover only REST API related code
+    # that's why these files are excluded
+    # If you want to exclude some files for another reason
+    # please do it above
+    src/index/__init__.py,
+    src/index/routes.py,
+
+    src/posts/__init__.py,
+    src/posts/forms.py,
+    src/posts/routes.py,
+
+    src/topics/__init__.py,
+    src/topics/forms.py,
+    src/topics/routes.py,
+
+    src/users/__init__.py,
+    src/users/forms.py,
+    src/users/routes.py,
+
+
 [report]
 exclude_lines =
     pragma: no cover

--- a/src/config.py
+++ b/src/config.py
@@ -7,7 +7,7 @@ class Config():  # pylint: disable=too-few-public-methods
     """Configuration class."""
 
     POSTGRES_DB = os.environ.get("POSTGRES_DB", "postgres")
-    POSTGRES_HOST = os.environ.get("POSTGRES_HOST", "localhost")
+    POSTGRES_HOST = os.environ.get("POSTGRES_HOST", "127.0.0.1")
     POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD", "")
     POSTGRES_PORT = os.environ.get("POSTGRES_PORT", "5432")
     POSTGRES_USER = os.environ.get("POSTGRES_USER", "postgres")


### PR DESCRIPTION
Since we decided to not test any ssr related code, we want to adjust our coverage config to check coverage only for the code run in our REST endpoints.

So in the scope of this task we need to adjust `.coveragerc` file to check only rest api related code.