### PR TITLE
134: Fix POSTGRES_HOST default value in config

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -7,7 +7,7 @@ class Config():  # pylint: disable=too-few-public-methods
     """Configuration class."""
 
     POSTGRES_DB = os.environ.get("POSTGRES_DB", "postgres")
-    POSTGRES_HOST = os.environ.get("POSTGRES_HOST", "127.0.0.1")
+    POSTGRES_HOST = os.environ.get("POSTGRES_HOST", "localhost")
     POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD", "")
     POSTGRES_PORT = os.environ.get("POSTGRES_PORT", "5432")
     POSTGRES_USER = os.environ.get("POSTGRES_USER", "postgres")


### PR DESCRIPTION
While working on adjusting coverage to check only rest code (#129) we mistakenly merged another default value for `POSTGRES_HOST` in `config.py`. This wasn't intentional and the previous value was correct.

So in the scope of this task we need to change `POSTGRES_HOST` default value in config to the previous value - `localhost`.