### PR TITLE
136: Fix app import in conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from alembic.config import main as alembic
 from sqlalchemy.orm import scoped_session, sessionmaker
 
-from src import app
+from src.app import app
 from src.database import engine, session_var
 from tests.utils.database import set_autoincrement_counters
 


### PR DESCRIPTION
While working on separating app initialization functionality (#83) we moved app instance from `src/__init__.py` to `src/app.py` but forgot to fix app import in `conftest.py`.

So in the scope of this task we need to fix app import in `conftest.py`.