### PR TITLE
126: Add tests for API auth endpoints

### DIFF
--- a/tests/auth/__init__.py
+++ b/tests/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for 'auth' REST api endpoints."""

--- a/tests/auth/test_auth_endpoint.py
+++ b/tests/auth/test_auth_endpoint.py
@@ -1,0 +1,19 @@
+"""Testing auth endpoint."""
+
+import jwt
+
+from src.config import Config
+
+
+def test_post_auth_endpoint_with_nonexistent_user_returns_400_with_correct_message(client, db_empty):
+    result = client.post("/api/auth", data={"username": "test", "password": "testtest"})
+
+    assert result.status_code == 400
+    assert result.json == {"message": "couldn't find user with credentials provided"}
+
+
+def test_post_auth_endpoint_with_existing_user_returns_correct_body(client, db_with_one_user):
+    result = client.post("/api/auth", data={"username": "test", "password": "testtest"})
+
+    assert result.status_code == 200
+    assert result.json == jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
+import hashlib
+
 import pytest
 from alembic.config import main as alembic
 from sqlalchemy.orm import scoped_session, sessionmaker
 
 from src.app import app
 from src.database import engine, session_var
+from src.users.models import User
 from tests.utils.database import set_autoincrement_counters
 
 
@@ -28,3 +31,13 @@ def db_empty():
     transaction.rollback()
     session.remove()
     connection.close()
+
+
+@pytest.fixture
+def db_with_one_user(db_empty):
+    session = db_empty
+    user = User(id=1, username="test")
+    user.password_hash = hashlib.sha256("testtest".encode()).hexdigest()
+    session.add(user)
+    session.commit()
+    return session


### PR DESCRIPTION
We want to cover our REST API part of the codebase with unit-tests.

In the scope of this task we need to cover authentication/authorization part of the REST API code.