### PR TITLE
139: Add missing pytest-env to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Linters order above is the preffered way to run and fix them one by one.
 
 1. Open terminal
 2. Run services using `docker-compose -f envs/test/docker-compose.yml up --detach` command.
-3. Type `POSTGRES_PORT=5433 pytest` command in terminal.
-   If you want to check coverage, run `POSTGRES_PORT=5433 pytest --cov=src`. This command also creates `htmlcov/index.html` file,
+3. Type `pytest` command in terminal.
+   If you want to check coverage, run `pytest --cov=src`. This command also creates `htmlcov/index.html` file,
 
 
 ### Working with migrations

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,6 +32,7 @@ mypy==0.991
 pylint==2.15.9
 pytest==7.2.0
 pytest-cov==4.0.0
+pytest-env==0.8.1
 sqlalchemy[mypy]==1.4.46
 
 


### PR DESCRIPTION
While working on adding unit-testing layout (#58), we used `env = ` section in `pytest.ini` config file to provide a correct postgres port for our testing database. But this section works only due-to [pytest-env](https://pypi.org/project/pytest-env/) plugin. We installed this plugin locally, but forgot to add it to the `requirements-dev.txt` so at the time of merging this functionality it seems to be worked, but it actually not.

This was revealed after some time. We noticed that `pytest` cannot connect to database for some reason. And at that time we solved this problem by adding `POSTGRES_PORT=5433` before `pytest` command in "Run tests" section of our README.md (#130). But to solve this problem we could just add pytest-env to our requirements, and leave `pytest` command without any additional env vars.

So in the scope of this task we need to revert changes made for (#130), and add `pytest-env` to our `requirements-dev.txt` file.