### PR TITLE
141: Fix pylint configuration to check tests

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -24,6 +24,7 @@ load-plugins=
     pylint.extensions.set_membership,  # Membership tests are more efficient when performed on a lookup optimized datatype like sets.
     pylint.extensions.typing,  # Find issue specifically related to type annotations
     pylint.extensions.while_used,  # While loops can often be rewritten as bounded for loops.
+    pylint_per_file_ignores,  # Adds 'per-file-ignores' section for pylint config
 
 
 [BASIC]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ There are other ways to do it correctly - choose any of these or find your own:
 2. Activate python virtual environment.
 3. Run `mypy`
 4. Run `flake8`
-5. Run `pylint src`
+5. Run `pylint src tests`
 
 Linters order above is the preffered way to run and fix them one by one.
 

--- a/envs/ci/docker-compose.yml
+++ b/envs/ci/docker-compose.yml
@@ -24,4 +24,4 @@ services:
 
   forum123-pylint:
     <<: *forum123-build
-    entrypoint: pylint --jobs=0 src
+    entrypoint: pylint --jobs=0 src tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.pylint-per-file-ignores]
+
+"tests/" = """ \
+    missing-module-docstring, \
+    missing-function-docstring, \
+    redefined-outer-name, \
+    unused-argument, \
+"""

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,6 +29,7 @@ flake8-spellcheck==0.24.0  # Spellcheck variables, classnames, comments, docstri
 flake8-type-checking==2.3.1  # Plugin for managing type-checking imports & forward references.
 flake8==3.9.2
 mypy==0.991
+pylint-per-file-ignores==1.2.0  # Adds 'per-file-ignores' section for pylint config
 pylint==2.15.9
 pytest==7.2.0
 pytest-cov==4.0.0


### PR DESCRIPTION
While working on adding unit-testing layout (#58) we forgot to setup pylint to check `tests` directory as well.

So in the scope of this task we need to fix pylint configuration and update `README.md` file to make pylint check `tests` directory.

***

Since pylint doesn't have anything like `per-file-ignores` we had to use [pylint-per-file-ignores](https://pypi.org/project/pylint-per-file-ignores/) plugin.

Since this plugin cannot work only with configuration in `pyproject.toml` we had to add one to define `per-file-ignores` in it.

***

All of this doesn't look good  so it's a temporary solution and I hope we will be able to find a better way to setup per file ignores for `pylint` in the future.