### PR TITLE
125: Add filtering to get posts REST endpoint

### DIFF
--- a/src/api/posts/utils.py
+++ b/src/api/posts/utils.py
@@ -1,5 +1,7 @@
 """Some utilities for api.posts."""
 
+from datetime import datetime
+
 from flask import abort
 
 from src.posts.models import Post
@@ -18,3 +20,25 @@ def parse_order_by(value: str) -> dict[str, str] | None:  # noqa: CFQ004  # pyli
     if parameter not in Post.SORTING_FIELDS or order not in Post.SORTING_ORDER:
         return abort(400, "provided value is not allowed")
     return {"field": parameter, "order": order}
+
+
+def parse_author_id(value: str) -> int | None:  # pylint: disable=duplicate-code
+    """Parse author_id query parameter."""
+    if not value:
+        return abort(400, "empty argument value is not allowed")
+    try:
+        int(value)
+    except ValueError:
+        return abort(400, "author id must be an integer")
+    return int(value)
+
+
+def parse_datetime(value: str) -> datetime | None:  # pylint: disable=duplicate-code
+    """Parse dates as strings and return datetime objects."""
+    if not value:
+        return abort(400, "empty argument value is not allowed")
+    try:
+        parsed_datetime = datetime.strptime(value, "%Y-%m-%d %H:%M:%S.%f")
+    except ValueError:
+        return abort(400, "invalid datetime string")
+    return parsed_datetime  # noqa: R504

--- a/src/api/topics/utils.py
+++ b/src/api/topics/utils.py
@@ -22,7 +22,7 @@ def parse_order_by(value: str) -> dict[str, str] | None:  # pylint: disable=dupl
     return {"field": parameter, "order": order}
 
 
-def parse_author_id(value: str) -> int | None:
+def parse_author_id(value: str) -> int | None:  # pylint: disable=duplicate-code
     """Parse author_id query parameter."""
     if not value:
         return abort(400, "empty argument value is not allowed")
@@ -33,7 +33,7 @@ def parse_author_id(value: str) -> int | None:
     return int(value)
 
 
-def parse_datetime(value: str) -> datetime | None:
+def parse_datetime(value: str) -> datetime | None:  # pylint: disable=duplicate-code
     """Parse dates as strings and return datetime objects."""
     if not value:
         return abort(400, "empty argument value is not allowed")

--- a/src/posts/models.py
+++ b/src/posts/models.py
@@ -36,10 +36,21 @@ class Post(Base):
         return session.query(Post).filter_by(id=post_id).first()
 
     @staticmethod
-    def get_posts_list(topic_id: int, sorting: dict[str, str] | None = None) -> list[Post]:
+    def get_posts_list(topic_id: int,
+                       sorting: dict[str, str] | None = None,
+                       author_ids: list[int] | None = None,
+                       created_before: datetime | None = None,
+                       created_after: datetime | None = None) -> list[Post]:
         """Use this method to get a list of posts of a certain topic."""
         sorting = {"field": "created_at", "order": "asc"} if sorting is None else sorting
         session = session_var.get()
+        posts_query = session.query(Post).filter_by(topic_id=topic_id)
+        if author_ids:
+            posts_query = posts_query.filter(Post.author_id.in_(author_ids))
+        if created_after:
+            posts_query = posts_query.filter(Post.created_at > created_after)
+        if created_before:
+            posts_query = posts_query.filter(Post.created_at < created_before)
         if sorting["order"] == "desc":
-            return session.query(Post).filter_by(topic_id=topic_id).order_by(desc(sorting["field"])).all()
-        return session.query(Post).filter_by(topic_id=topic_id).order_by(sorting["field"]).all()
+            return posts_query.order_by(desc(sorting["field"])).all()
+        return posts_query.order_by(sorting["field"]).all()


### PR DESCRIPTION
We need to add filtration to the `get_posts` REST route. Filtering should be possible by the following attributes: `author_id`, `created_before`, `created_after`.

**Request example**
```http
GET /topics/42/posts?author_id=42&author_id=24&author_id=18
```

**Response example**
```python
[
    # posts with author_id 42 or 24 or 18
]
```

We suppose that all datetime related query params will be sent in UTC timezone in the following format:
```text
'2023-04-24 05:10:20.782336'
```

**Request example**

```http
GET /topics/42/posts?created_after=2023-04-24 04:10:20.782336&created_before=2023-04-24 05:10:20.782336
```

So in the scope of this task we need to add filtration for `get_posts` route.