### PR TITLE
144: Fix filtering by author_id for topics

### DIFF
--- a/src/api/topics/routes.py
+++ b/src/api/topics/routes.py
@@ -34,7 +34,7 @@ class TopicList(Resource):  # type: ignore
         parsed_args = parser.parse_args()
         topics = Topic.get_topics(
             sorting=parsed_args.get("order_by"),
-            author_ids=parsed_args.get("author_ids"),
+            author_ids=parsed_args.get("author_id"),
             created_before=parsed_args.get("created_before"),
             created_after=parsed_args.get("created_after"),
         )


### PR DESCRIPTION
While working on adding filtering to get topics REST endpoint (#124), we made a type in this line:
```python
author_ids=parsed_args.get("author_ids")
```
This actually should be `.get("author_id")`, because we named this parameter as `"author_id"` in our `reqparse`:
```python
parser.add_argument("author_id", type=parse_author_id, action="append")
```

This caused a bug in our filtration - filtration wasn't applied if author ids were provided.

So in the scope of this task we need to change this:
```python
author_ids=parsed_args.get("author_ids")
```

to this:
```python
author_ids=parsed_args.get("author_id")
```