### PR TITLE
146: Fix reqparse error handling

### DIFF
--- a/src/api/auth/routes.py
+++ b/src/api/auth/routes.py
@@ -2,9 +2,10 @@
 
 import jwt
 from flask import abort
-from flask_restx import Namespace, reqparse, Resource
+from flask_restx import Namespace, Resource
 
 from src.config import Config
+from src.shared import reqparse
 from src.users.models import User
 
 

--- a/src/api/auth/utils.py
+++ b/src/api/auth/utils.py
@@ -7,10 +7,10 @@ from typing import Any, ParamSpec, TYPE_CHECKING, TypeVar
 
 import jwt
 from flask import abort
-from flask_restx import reqparse
 from jwt import InvalidTokenError
 
 from src.config import Config
+from src.shared import reqparse
 from src.users.models import User
 
 if TYPE_CHECKING:

--- a/src/api/posts/routes.py
+++ b/src/api/posts/routes.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING
 
 from flask import abort
-from flask_restx import Namespace, reqparse, Resource
+from flask_restx import Namespace, Resource
 
 from src.api.auth.utils import authorized_access
 from src.api.posts.utils import parse_author_id, parse_datetime, parse_order_by
 from src.api.topics.routes import ns as topics_ns
 from src.posts.models import Post
+from src.shared import reqparse
 from src.topics.models import Topic
 
 if TYPE_CHECKING:

--- a/src/api/topics/routes.py
+++ b/src/api/topics/routes.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING
 
 from flask import abort
-from flask_restx import Namespace, reqparse, Resource
+from flask_restx import Namespace, Resource
 
 from src.api.auth.utils import authorized_access
 from src.api.topics.utils import parse_author_id, parse_datetime, parse_order_by
+from src.shared import reqparse
 from src.topics.models import Topic
 
 if TYPE_CHECKING:

--- a/src/api/users/routes.py
+++ b/src/api/users/routes.py
@@ -3,10 +3,11 @@
 from typing import Any
 
 from flask import abort
-from flask_restx import Namespace, reqparse, Resource
+from flask_restx import Namespace, Resource
 
 from src.api.auth.utils import authorized_access
 from src.api.users.utils import parse_order_by
+from src.shared import reqparse
 from src.users.models import User
 
 

--- a/src/shared/__init__.py
+++ b/src/shared/__init__.py
@@ -1,0 +1,1 @@
+"""Provides components shared by different application modules."""

--- a/src/shared/reqparse.py
+++ b/src/shared/reqparse.py
@@ -1,0 +1,26 @@
+"""This module provides a customized version of flask-restx's reqparse features."""
+
+from typing import Any, NoReturn
+
+from flask import abort
+from flask_restx import reqparse
+
+
+class RequestParser(reqparse.RequestParser):  # type: ignore
+    """Customized version of flask-restx's RequestParser class."""
+
+    def __init__(self, *args: list[Any], **kwargs: Any) -> None:
+        """Init method."""
+        if "argument_class" not in kwargs:
+            kwargs["argument_class"] = Argument
+        super().__init__(*args, **kwargs)
+
+
+class Argument(reqparse.Argument):  # type: ignore
+    """Customized version of flask-restx's Argument class."""
+
+    def handle_validation_error(self, error: str | Exception, bundle_errors: bool) -> NoReturn:
+        """Reraise exception from parser function."""
+        if isinstance(error, str):  # exceptions raised by flask-restx request parser itself
+            abort(400, error)
+        raise error  # any other error caught by flask-restx request parser


### PR DESCRIPTION
While working on adding REST API endpoints (#98, #105, #107, #112, #118) we used `reqparse.RequestParser` from `flask_restx`. But we didn't take into account that this RequestParser has its own exception handling. This means that some code defined in parser like this:
```python
def parse_token_data(header: str) -> dict[str, int]:
    """Parse and validate JWT authorization token from Authorization request header."""
    scheme, _, token = header.partition(" ")
    if scheme != "Bearer" or token == "":  # pylint: disable=compare-to-empty-string
        return abort(401, "invalid token")
    try:
        return jwt.decode(token, Config.SECRET_KEY, algorithms=["HS256"])
    except InvalidTokenError:
        return abort(401, "invalid token")
```
will not use our 401 HTTP code we're trying to return. RequestParser catches any errors raised during parsing arguments and returns 400 error with message from raised exception.

So in the scope of this ticket we need to fix that behaviour. We want to prevent RequestParser from flask_restx to catch and override errors. As a result we expect that all error raised by our parser code will be bubbled up to the response to the user.