### PR TITLE
46: Fix vars context in workflows

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           GITHUB_EVENT_REF: ${{ github.event.ref }}  # we use `github.event.ref` here because `vars.GITHUB_REF_NAME`
                                                      # for deleted branch will point to default branch
-          GITHUB_REPOSITORY: ${{ vars.GITHUB_REPOSITORY }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python envs/ci/scripts/github/cleanup_runs_for_deleted_branch.py
 
@@ -60,7 +60,7 @@ jobs:
 
       - name: Clean up workflow runs for current branch after rebase
         env:
-          GITHUB_REF_NAME: ${{ vars.GITHUB_REF_NAME }}
-          GITHUB_REPOSITORY: ${{ vars.GITHUB_REPOSITORY }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python envs/ci/scripts/github/cleanup_runs_for_rebased_branch.py


### PR DESCRIPTION
It was definitely a mistake to use `vars` context in our GitHub Actions workflows. Now all values we're trying to get from `vars` are evaluated to empty strings (which of course is unexpected behavior) and everything works just by accident.

Actually [`vars` context](https://docs.github.com/en/actions/learn-github-actions/contexts#vars-context) should be used to get variables which were set at the organization, repository, and environment levels. And everywhere we're using it, we don't really want to get these values from org, repo or environment. Now we don't have any org/repo/env variables, that's why all variables from `vars` are evaluated to empty string for us.

***

UPD

For `develop` branch at 93c4a6a:

I doublechecked this behaviour and it works - `{{ vars.GITHUB_REF_NAME }}` points to the current branch and `{{ vars.GITHUB_REPOSITORY }}` points to this repository correctly.

But there is no concrete words in GitHub Actions docs that `vars` context always will contain this variables. And vscode extension for GitHub Actions shows these warnings:

![image](https://user-images.githubusercontent.com/35929293/236198934-8250ec72-7e20-4b6b-adb1-6198014f29bc.png)

So we decided to use correct context `github` instead of `vars` to always be sure that it will work fine.