### PR TITLE
127: Add tests for api/topics endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,5 @@
     missing-function-docstring, \
     redefined-outer-name, \
     unused-argument, \
+    unused-variable, \
 """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import datetime
 import hashlib
 
 import pytest
@@ -6,6 +7,7 @@ from sqlalchemy.orm import scoped_session, sessionmaker
 
 from src.app import app
 from src.database import engine, session_var
+from src.topics.models import Topic
 from src.users.models import User
 from tests.utils.database import set_autoincrement_counters
 
@@ -39,5 +41,53 @@ def db_with_one_user(db_empty):
     user = User(id=1, username="test")
     user.password_hash = hashlib.sha256("testtest".encode()).hexdigest()
     session.add(user)
+    session.commit()
+    return session
+
+
+@pytest.fixture
+def db_with_one_user_and_one_topic(db_with_one_user):
+    session = db_with_one_user
+    creation_time = "2023-05-06 00:12:38.078953"
+    topic = Topic(id=1, title="test title", description="test desc", author_id=1,
+                  created_at=datetime.datetime.strptime(creation_time, "%Y-%m-%d %H:%M:%S.%f"))
+    session.add(topic)
+    session.commit()
+    return session
+
+
+@pytest.fixture
+def db_with_three_users(db_with_one_user):
+    session = db_with_one_user
+
+    user_two = User(id=2, username="test2")
+    user_two.password_hash = hashlib.sha256("testtest2".encode()).hexdigest()
+    session.add(user_two)
+
+    user_three = User(id=3, username="test3")
+    user_three.password_hash = hashlib.sha256("testtest3".encode()).hexdigest()
+    session.add(user_three)
+
+    session.commit()
+    return session
+
+
+@pytest.fixture
+def db_with_three_users_and_three_topics(db_with_three_users):
+    session = db_with_three_users
+    creation_time = "2023-05-06 00:12:38.078953"
+    topic_one = Topic(id=1, title="test title", description="test desc", author_id=1,
+                      created_at=datetime.datetime.strptime(creation_time, "%Y-%m-%d %H:%M:%S.%f"))
+    session.add(topic_one)
+
+    topic_two = Topic(id=2, title="test title2", description="test desc2", author_id=2,
+                      created_at=datetime.datetime.strptime(creation_time, "%Y-%m-%d %H:%M:%S.%f"))
+    session.add(topic_two)
+
+    topic_three = Topic(id=3, title="test title3", description="test desc3", author_id=3)
+    topic_three.created_at = datetime.datetime.strptime(creation_time,
+                                                        "%Y-%m-%d %H:%M:%S.%f") + datetime.timedelta(days=1)
+    session.add(topic_three)
+
     session.commit()
     return session

--- a/tests/topics/__init__.py
+++ b/tests/topics/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for 'topics' REST api endpoints."""

--- a/tests/topics/test_topic_info_endpoint.py
+++ b/tests/topics/test_topic_info_endpoint.py
@@ -1,0 +1,37 @@
+"""Testing TopicInfo endpoint."""
+
+import jwt
+
+from src.config import Config
+
+
+def test_get_topic_info_endpoint_with_authorized_user_returns_200_with_correct_body(client,
+                                                                                    db_with_one_user_and_one_topic):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("/api/topics/1", headers={"Authorization": f"Bearer {authorization_token}"})
+
+    assert result.status_code == 200
+    assert result.json == {
+        "author_id": 1,
+        "created_at": "2023-05-06 00:12:38.078953",
+        "description": "test desc",
+        "title": "test title",
+    }
+
+
+def test_get_topic_info_endpoint_with_nonexistent_topic_returns_404_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("/api/topics/1", headers={"Authorization": f"Bearer {authorization_token}"})
+
+    assert result.status_code == 404
+    assert result.json == {"message": "Could not find a topic with id provided."}
+
+
+def test_get_topic_info_endpoint_with_invalid_token_returns_401_with_correct_body(client,
+                                                                                  db_with_one_user_and_one_topic):
+    result = client.get("/api/topics/1", headers={"Authorization": "Bearer IvalidToken"})
+
+    assert result.status_code == 401
+    assert result.json == {"message": "invalid token"}

--- a/tests/topics/test_topic_list_endpoint.py
+++ b/tests/topics/test_topic_list_endpoint.py
@@ -1,0 +1,261 @@
+"""Testing TopicList endpoint."""
+
+from datetime import datetime
+
+import jwt
+
+from src.config import Config
+from src.topics.models import Topic
+
+
+def test_get_topic_list_endpoint_with_no_args_returns_200_with_correct_body(client,
+                                                                            db_with_three_users_and_three_topics):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics", headers={"Authorization": f"Bearer {authorization_token}"})
+
+    assert result.status_code == 200
+    assert result.json == [
+        {
+            "id": 1,
+            "author_id": 1,
+            "created_at": "2023-05-06 00:12:38.078953",
+            "description": "test desc",
+            "title": "test title",
+        },
+        {
+            "id": 2,
+            "author_id": 2,
+            "created_at": "2023-05-06 00:12:38.078953",
+            "description": "test desc2",
+            "title": "test title2",
+        },
+        {
+            "id": 3,
+            "author_id": 3,
+            "created_at": "2023-05-07 00:12:38.078953",
+            "description": "test desc3",
+            "title": "test title3",
+        },
+    ]
+
+
+def test_get_topic_list_endpoint_with_order_by_returns_200_with_correct_body(client,
+                                                                             db_with_three_users_and_three_topics):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"order_by": "title,desc"})
+
+    assert result.status_code == 200
+    assert result.json == [
+        {
+            "id": 3,
+            "author_id": 3,
+            "created_at": "2023-05-07 00:12:38.078953",
+            "description": "test desc3",
+            "title": "test title3",
+        },
+        {
+            "id": 2,
+            "author_id": 2,
+            "created_at": "2023-05-06 00:12:38.078953",
+            "description": "test desc2",
+            "title": "test title2",
+        },
+        {
+            "id": 1,
+            "author_id": 1,
+            "created_at": "2023-05-06 00:12:38.078953",
+            "description": "test desc",
+            "title": "test title",
+        },
+    ]
+
+
+def test_get_topic_list_endpoint_with_empty_order_by_returns_400_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"order_by": ""})
+
+    assert result.status_code == 400
+    assert result.json == {"message": "empty argument value is not allowed"}
+
+
+def test_get_topic_list_endpoint_with_invalid_order_by_returns_400_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"order_by": "InvalidArgument"})
+
+    assert result.status_code == 400
+    assert result.json == {"message": "failed parsing parameters provided"}
+
+
+def test_get_topic_list_endpoint_with_not_allowed_order_by_returns_400_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"order_by": "author_id,desc"})
+
+    assert result.status_code == 400
+    assert result.json == {"message": "provided value is not allowed"}
+
+
+def test_get_topic_list_endpoint_with_author_id_returns_200_with_correct_body(client,
+                                                                              db_with_three_users_and_three_topics):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"author_id": [1, 3]})
+
+    assert result.status_code == 200
+    assert result.json == [
+        {
+            "id": 1,
+            "author_id": 1,
+            "created_at": "2023-05-06 00:12:38.078953",
+            "description": "test desc",
+            "title": "test title",
+        },
+        {
+            "id": 3,
+            "author_id": 3,
+            "created_at": "2023-05-07 00:12:38.078953",
+            "description": "test desc3",
+            "title": "test title3",
+        },
+    ]
+
+
+def test_get_topic_list_endpoint_with_empty_author_id_returns_400_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"author_id": ""})
+
+    assert result.status_code == 400
+    assert result.json == {"message": "empty argument value is not allowed"}
+
+
+def test_get_topic_list_endpoint_with_invalid_author_id_returns_400_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"author_id": "InvalidArgument"})
+
+    assert result.status_code == 400
+    assert result.json == {"message": "author id must be an integer"}
+
+
+def test_get_topic_list_endpoint_with_created_before_returns_200_with_correct_body(
+    client, db_with_three_users_and_three_topics,
+):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"created_before": "2023-05-07 00:12:38.078953"})
+
+    assert result.status_code == 200
+    assert result.json == [
+        {
+            "id": 1,
+            "author_id": 1,
+            "created_at": "2023-05-06 00:12:38.078953",
+            "description": "test desc",
+            "title": "test title",
+        },
+        {
+            "id": 2,
+            "author_id": 2,
+            "created_at": "2023-05-06 00:12:38.078953",
+            "description": "test desc2",
+            "title": "test title2",
+        },
+    ]
+
+
+def test_get_topic_list_endpoint_with_created_after_returns_200_with_correct_body(
+    client, db_with_three_users_and_three_topics,
+):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"created_after": "2023-05-06 00:12:38.078953"})
+
+    assert result.status_code == 200
+    assert result.json == [
+        {
+            "id": 3,
+            "author_id": 3,
+            "created_at": "2023-05-07 00:12:38.078953",
+            "description": "test desc3",
+            "title": "test title3",
+        },
+    ]
+
+
+def test_get_topic_list_endpoint_with_empty_created_before_returns_400_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"created_before": ""})
+
+    assert result.status_code == 400
+    assert result.json == {"message": "empty argument value is not allowed"}
+
+
+def test_get_topic_list_endpoint_with_invalid_created_before_returns_400_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"created_before": "InvalidArgument"})
+
+    assert result.status_code == 400
+    assert result.json == {"message": "invalid datetime string"}
+
+
+def test_post_topic_list_endpoint_with_valid_args_returns_200_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.post("api/topics", headers={"Authorization": f"Bearer {authorization_token}"},
+                         query_string={"title": "test", "description": "testtest"})
+
+    assert result.status_code == 200
+    response_body = result.json
+    post_id = response_body.pop("id")
+    assert isinstance(post_id, int)
+    assert response_body == {
+        # "id": 10000,  # noqa
+        "author_id": 1,
+        "description": "testtest",
+        "title": "test",
+    }
+
+
+def test_post_topic_list_endpoint_with_valid_args_creates_objects_in_db_correctly(client, db_with_one_user):
+    session = db_with_one_user
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.post("api/topics", headers={"Authorization": f"Bearer {authorization_token}"},
+                         query_string={"title": "test", "description": "testtest"})
+
+    topics = session.query(Topic).all()
+    assert len(topics) == 1
+    created_topic = topics[0]
+    assert created_topic.created_at < datetime.now()
+    assert created_topic.title == "test"
+    assert created_topic.description == "testtest"
+    assert created_topic.author_id == 1
+    assert isinstance(created_topic.id, int)
+
+
+def test_post_topic_list_endpoint_with_empty_args_returns_400_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.post("api/topics", headers={"Authorization": f"Bearer {authorization_token}"},
+                         query_string={"title": "", "description": ""})
+
+    assert result.status_code == 400
+    assert result.json == {"message": "invalid request"}


### PR DESCRIPTION
We want to cover our REST API part of the codebase with unit-tests.

In the scope of this task we need to cover code which is working with topics in our REST API.