### PR TITLE
149: Add tests for api/posts endpoints

### DIFF
--- a/src/api/posts/routes.py
+++ b/src/api/posts/routes.py
@@ -82,7 +82,7 @@ class PostInfo(Resource):  # type: ignore
         if not (post := Post.get_post_by_id(post_id)):
             return abort(404, "Could not find a post with id provided.")
         return {
-            "author_id": post.id,
+            "author_id": post.author_id,
             "created_at": str(post.created_at),
             "body": post.body,
             "topic_id": post.topic_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import scoped_session, sessionmaker
 
 from src.app import app
 from src.database import engine, session_var
+from src.posts.models import Post
 from src.topics.models import Topic
 from src.users.models import User
 from tests.utils.database import set_autoincrement_counters
@@ -90,4 +91,45 @@ def db_with_three_users_and_three_topics(db_with_three_users):
     session.add(topic_three)
 
     session.commit()
+    return session
+
+
+@pytest.fixture
+def db_with_one_of_user_topic_post(db_with_one_user_and_one_topic):
+    session = db_with_one_user_and_one_topic
+    creation_time = "2023-05-06 00:12:38.078953"
+
+    post = Post(id=1, author_id=1, body="test body", topic_id=1,
+                created_at=datetime.datetime.strptime(creation_time, "%Y-%m-%d %H:%M:%S.%f"))
+
+    session.add(post)
+    session.commit()
+
+    return session
+
+
+@pytest.fixture
+def db_with_three_users_one_topic_three_posts(db_with_three_users):
+    session = db_with_three_users
+    creation_time = "2023-05-06 00:12:38.078953"
+
+    topic = Topic(id=1, title="test title", description="test desc", author_id=1,
+                  created_at=datetime.datetime.strptime(creation_time, "%Y-%m-%d %H:%M:%S.%f"))
+    session.add(topic)
+
+    post_one = Post(id=1, author_id=1, body="test body", topic_id=1,
+                    created_at=datetime.datetime.strptime(creation_time, "%Y-%m-%d %H:%M:%S.%f"))
+    session.add(post_one)
+
+    post_two = Post(id=2, author_id=2, body="test body2", topic_id=1)
+    post_two.created_at = datetime.datetime.strptime(creation_time,
+                                                     "%Y-%m-%d %H:%M:%S.%f") + datetime.timedelta(days=1)
+    session.add(post_two)
+
+    post_three = Post(id=3, author_id=3, body="test body3", topic_id=1)
+    post_three.created_at = datetime.datetime.strptime(creation_time,
+                                                       "%Y-%m-%d %H:%M:%S.%f") + datetime.timedelta(days=2)
+    session.add(post_three)
+    session.commit()
+
     return session

--- a/tests/posts/__init__.py
+++ b/tests/posts/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for 'posts' REST api endpoints."""

--- a/tests/posts/test_post_info_endpoint.py
+++ b/tests/posts/test_post_info_endpoint.py
@@ -1,0 +1,29 @@
+"""Testing PostInfo endpoint."""
+
+import jwt
+
+from src.config import Config
+
+
+def test_get_post_info_endpoint_with_authorized_user_returns_200_with_correct_body(client,
+                                                                                   db_with_one_of_user_topic_post):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("/api/posts/1", headers={"Authorization": f"Bearer {authorization_token}"})
+
+    assert result.status_code == 200
+    assert result.json == {
+        "author_id": 1,
+        "created_at": "2023-05-06 00:12:38.078953",
+        "body": "test body",
+        "topic_id": 1,
+    }
+
+
+def test_get_post_info_endpoint_with_nonexistent_post_returns_404_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("/api/posts/1", headers={"Authorization": f"Bearer {authorization_token}"})
+
+    assert result.status_code == 404
+    assert result.json == {"message": "Could not find a post with id provided."}

--- a/tests/posts/test_posts_list_endpoint.py
+++ b/tests/posts/test_posts_list_endpoint.py
@@ -1,0 +1,266 @@
+"""Testing PostsList endpoint."""
+
+from datetime import datetime
+
+import jwt
+
+from src.config import Config
+from src.posts.models import Post
+
+
+def test_get_posts_list_endpoint_with_no_args_returns_200_with_correct_body(client,
+                                                                            db_with_three_users_one_topic_three_posts):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics/1/posts", headers={"Authorization": f"Bearer {authorization_token}"})
+
+    assert result.status_code == 200
+    assert result.json == [
+        {
+            "id": 1,
+            "author_id": 1,
+            "body": "test body",
+            "created_at": "2023-05-06 00:12:38.078953",
+            "topic_id": 1,
+        },
+        {
+            "id": 2,
+            "author_id": 2,
+            "body": "test body2",
+            "created_at": "2023-05-07 00:12:38.078953",
+            "topic_id": 1,
+        },
+        {
+            "id": 3,
+            "author_id": 3,
+            "body": "test body3",
+            "created_at": "2023-05-08 00:12:38.078953",
+            "topic_id": 1,
+        },
+    ]
+
+
+def test_get_posts_list_endpoint_with_nonexistent_topic_returns_404_with_correct_body(client,
+                                                                                      db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics/1/posts", headers={"Authorization": f"Bearer {authorization_token}"})
+
+    assert result.status_code == 404
+    assert result.json == {"message": "topic does not exist"}
+
+
+def test_get_posts_list_endpoint_with_order_by_returns_200_with_correct_body(client,
+                                                                             db_with_three_users_one_topic_three_posts):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics/1/posts", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"order_by": "created_at,desc"})
+
+    assert result.status_code == 200
+    assert result.json == [
+        {
+            "id": 3,
+            "author_id": 3,
+            "body": "test body3",
+            "created_at": "2023-05-08 00:12:38.078953",
+            "topic_id": 1,
+        },
+        {
+            "id": 2,
+            "author_id": 2,
+            "body": "test body2",
+            "created_at": "2023-05-07 00:12:38.078953",
+            "topic_id": 1,
+        },
+        {
+            "id": 1,
+            "author_id": 1,
+            "body": "test body",
+            "created_at": "2023-05-06 00:12:38.078953",
+            "topic_id": 1,
+        },
+    ]
+
+
+def test_get_posts_list_endpoint_with_empty_order_by_returns_400_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics/1/posts", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"order_by": ""})
+
+    assert result.status_code == 400
+    assert result.json == {"message": "empty argument value is not allowed"}
+
+
+def test_get_posts_list_endpoint_with_invalid_order_by_returns_400_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics/1/posts", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"order_by": "InvalidArgument"})
+
+    assert result.status_code == 400
+    assert result.json == {"message": "failed parsing parameters provided"}
+
+
+def test_get_posts_list_endpoint_with_not_allowed_order_by_returns_400_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics/1/posts", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"order_by": "author_id,desc"})
+
+    assert result.status_code == 400
+    assert result.json == {"message": "provided value is not allowed"}
+
+
+def test_get_posts_list_endpoint_with_author_id_returns_200_with_correct_body(
+        client, db_with_three_users_one_topic_three_posts,
+):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics/1/posts", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"author_id": [1, 3]})
+
+    assert result.status_code == 200
+    assert result.json == [
+        {
+            "id": 1,
+            "author_id": 1,
+            "body": "test body",
+            "created_at": "2023-05-06 00:12:38.078953",
+            "topic_id": 1,
+        },
+        {
+            "id": 3,
+            "author_id": 3,
+            "body": "test body3",
+            "created_at": "2023-05-08 00:12:38.078953",
+            "topic_id": 1,
+        },
+    ]
+
+
+def test_get_posts_list_endpoint_with_empty_author_id_returns_400_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics/1/posts", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"author_id": ""})
+
+    assert result.status_code == 400
+    assert result.json == {"message": "empty argument value is not allowed"}
+
+
+def test_get_posts_list_endpoint_with_invalid_author_id_returns_400_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics/1/posts", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"author_id": "InvalidArgument"})
+
+    assert result.status_code == 400
+    assert result.json == {"message": "author id must be an integer"}
+
+
+def test_get_posts_list_endpoint_with_created_before_returns_200_with_correct_body(
+    client, db_with_three_users_one_topic_three_posts,
+):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics/1/posts", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"created_before": "2023-05-07 00:12:38.078953"})
+
+    assert result.status_code == 200
+    assert result.json == [
+        {
+            "id": 1,
+            "author_id": 1,
+            "body": "test body",
+            "created_at": "2023-05-06 00:12:38.078953",
+            "topic_id": 1,
+        },
+    ]
+
+
+def test_get_posts_list_endpoint_with_created_after_returns_200_with_correct_body(
+    client, db_with_three_users_one_topic_three_posts,
+):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics/1/posts", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"created_after": "2023-05-07 00:12:38.078953"})
+
+    assert result.status_code == 200
+    assert result.json == [
+        {
+            "id": 3,
+            "author_id": 3,
+            "body": "test body3",
+            "created_at": "2023-05-08 00:12:38.078953",
+            "topic_id": 1,
+        },
+    ]
+
+
+def test_get_posts_list_endpoint_with_empty_created_before_returns_400_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics/1/posts", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"created_before": ""})
+
+    assert result.status_code == 400
+    assert result.json == {"message": "empty argument value is not allowed"}
+
+
+def test_get_posts_list_endpoint_with_invalid_created_before_returns_400_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics/1/posts", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"created_before": "InvalidArgument"})
+
+    assert result.status_code == 400
+    assert result.json == {"message": "invalid datetime string"}
+
+
+def test_post_posts_list_endpoint_with_valid_args_returns_200_with_correct_body(client, db_with_one_user_and_one_topic):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.post("api/topics/1/posts", headers={"Authorization": f"Bearer {authorization_token}"},
+                         query_string={"body": "test"})
+
+    assert result.status_code == 200
+    response_body = result.json
+    post_id = response_body.pop("id")
+    assert isinstance(post_id, int)
+    assert response_body == {
+        # "id": 10000,  # noqa
+        "author_id": 1,
+        "body": "test",
+        "topic_id": 1,
+    }
+
+
+def test_post_posts_list_endpoint_with_valid_args_creates_objects_in_db_correctly(
+        client, db_with_one_user_and_one_topic,
+):
+    session = db_with_one_user_and_one_topic
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.post("api/topics/1/posts", headers={"Authorization": f"Bearer {authorization_token}"},
+                         query_string={"body": "test"})
+
+    posts = session.query(Post).all()
+    assert len(posts) == 1
+    created_post = posts[0]
+    assert created_post.created_at < datetime.now()
+    assert created_post.body == "test"
+    assert created_post.author_id == 1
+    assert isinstance(created_post.id, int)
+
+
+def test_post_posts_list_endpoint_with_nonexistent_topic_returns_404_with_correct_body(client,
+                                                                                       db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics/1/posts", headers={"Authorization": f"Bearer {authorization_token}"})
+
+    assert result.status_code == 404
+    assert result.json == {"message": "topic does not exist"}

--- a/tests/topics/test_topic_list_endpoint.py
+++ b/tests/topics/test_topic_list_endpoint.py
@@ -259,3 +259,29 @@ def test_post_topic_list_endpoint_with_empty_args_returns_400_with_correct_body(
 
     assert result.status_code == 400
     assert result.json == {"message": "invalid request"}
+
+
+def test_get_topic_list_endpoint_with_no_bearer_prefix_returns_401_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics", headers={"Authorization": f"InvalidBearerPrefix {authorization_token}"})
+
+    assert result.status_code == 401
+    assert result.json == {"message": "invalid token"}
+
+
+def test_get_topic_list_endpoint_with_empty_auth_token_returns_401_with_correct_body(client, db_with_one_user):
+
+    result = client.get("api/topics", headers={"Authorization": "Bearer"})
+
+    assert result.status_code == 401
+    assert result.json == {"message": "invalid token"}
+
+
+def test_get_topic_list_endpoint_with_nonexistent_user_auth_returns_401_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 0}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/topics", headers={"Authorization": f"Bearer {authorization_token}"})
+
+    assert result.status_code == 403
+    assert result.json == {"message": "user not found"}


### PR DESCRIPTION
We want to cover our REST API part of the codebase with unit-tests.

In the scope of this task we need to cover code which is working with posts in our REST API.