### PR TITLE
154: Separate parser instances for each route

### DIFF
--- a/src/api/auth/routes.py
+++ b/src/api/auth/routes.py
@@ -11,8 +11,6 @@ from src.users.models import User
 
 ns = Namespace("auth", path="/auth")
 
-parser = reqparse.RequestParser()
-
 
 @ns.route("")
 class AuthEndpoint(Resource):  # type: ignore
@@ -21,6 +19,7 @@ class AuthEndpoint(Resource):  # type: ignore
     @staticmethod
     def post() -> str | None:
         """Authenticate credentials and return JWT token."""
+        parser = reqparse.RequestParser()
         parser.add_argument("username", required=True, type=str)
         parser.add_argument("password", required=True, type=str)
         credentials = parser.parse_args()

--- a/src/api/posts/routes.py
+++ b/src/api/posts/routes.py
@@ -20,8 +20,6 @@ if TYPE_CHECKING:
 
 ns = Namespace("posts", path="/posts")
 
-parser = reqparse.RequestParser()
-
 
 @topics_ns.route("/<int:topic_id>/posts")
 class PostsList(Resource):  # type: ignore
@@ -31,6 +29,7 @@ class PostsList(Resource):  # type: ignore
     @authorized_access()
     def get(topic_id: int) -> list[dict[str, Any]] | None:
         """Get a list of posts of a certain topic."""
+        parser = reqparse.RequestParser()
         parser.add_argument("order_by", type=parse_order_by)  # pylint: disable=duplicate-code
         parser.add_argument("author_id", type=parse_author_id, action="append")
         parser.add_argument("created_after", type=parse_datetime)
@@ -57,6 +56,7 @@ class PostsList(Resource):  # type: ignore
     @authorized_access(provide_user=True)
     def post(topic_id: int, user: User) -> dict[str, Any]:
         """Create a new post."""
+        parser = reqparse.RequestParser()
         parser.add_argument("body", required=True)
         post_info = parser.parse_args()
         if not (topic := Topic.get(topic_id)):

--- a/src/api/topics/routes.py
+++ b/src/api/topics/routes.py
@@ -17,8 +17,6 @@ if TYPE_CHECKING:
 
 ns = Namespace("topics", path="/topics")
 
-parser = reqparse.RequestParser()
-
 
 @ns.route("")
 class TopicList(Resource):  # type: ignore
@@ -28,6 +26,7 @@ class TopicList(Resource):  # type: ignore
     @authorized_access()
     def get() -> list[dict[str, Any]] | None:
         """Get a sorted list of all topics."""
+        parser = reqparse.RequestParser()
         parser.add_argument("order_by", type=parse_order_by)
         parser.add_argument("author_id", type=parse_author_id, action="append")
         parser.add_argument("created_after", type=parse_datetime)
@@ -51,6 +50,7 @@ class TopicList(Resource):  # type: ignore
     @authorized_access(provide_user=True)
     def post(user: User) -> dict[str, Any]:
         """Create topic and return its' info."""
+        parser = reqparse.RequestParser()
         parser.add_argument("title", required=True)
         parser.add_argument("description", required=True)
         topic_info = parser.parse_args()

--- a/src/api/users/routes.py
+++ b/src/api/users/routes.py
@@ -13,8 +13,6 @@ from src.users.models import User
 
 ns = Namespace("users", path="/users")
 
-parser = reqparse.RequestParser()
-
 
 @ns.route("")
 class UserList(Resource):  # type: ignore
@@ -24,6 +22,7 @@ class UserList(Resource):  # type: ignore
     @authorized_access()
     def get() -> list[dict[str, Any]] | None:
         """Get a list of all users, sorted if needed."""
+        parser = reqparse.RequestParser()
         parser.add_argument("order_by", type=parse_order_by, help="get a sorted list of users")
         sorting_parameters = parser.parse_args()
         users = User.get_users(sorting_parameters["order_by"])


### PR DESCRIPTION
Now we create one parser instance for all routes within a file. And after that each route adds each own arguments to the parser.

This means that when we run different routes in our application each route within a file will try to parse arguments added by different routes. But we need a parser to have arguments only for one route each time.

So in the scope of this ticket we need to fix that by creating a separate parser instance for each route.