### PR TITLE
Fix response for get post REST endpoint

### DIFF
--- a/src/api/posts/routes.py
+++ b/src/api/posts/routes.py
@@ -82,7 +82,8 @@ class PostInfo(Resource):  # type: ignore
         if not (post := Post.get_post_by_id(post_id)):
             return abort(404, "Could not find a post with id provided.")
         return {
-            "author_id": post.id,
+            "id": post.id,
+            "author_id": post.author_id,
             "created_at": str(post.created_at),
             "body": post.body,
             "topic_id": post.topic_id,


### PR DESCRIPTION
While working on adding REST endpoint to get post (#102), we added wrong response body:
```python
return {
    "author_id": post.id,
    "created_at": str(post.created_at),
    "body": post.body,
    "topic_id": post.topic_id,
}
```
This body doesn't contain "id" and has a wrong value in "author_id".

So in the scope of this task we need to fix these two fields. "id" should contain a post id and "author_id" should contain id of the post author.