### PR TITLE
155: Add test for api/users endpoints

### DIFF
--- a/src/users/models.py
+++ b/src/users/models.py
@@ -28,7 +28,7 @@ class User(Base):
     def _get_password_hash(password: str) -> str:
         return hashlib.sha256(password.encode()).hexdigest()
 
-    def set_password(self, password: str) -> None:
+    def set_password(self, password: str) -> None:  # pragma: no cover
         """Use this method to set hashed password to User."""
         self.password_hash = self._get_password_hash(password)
 
@@ -37,7 +37,7 @@ class User(Base):
         return self._get_password_hash(password_to_check) == self.password_hash
 
     @classmethod
-    def create_user(cls, username: str, password: str) -> User:
+    def create_user(cls, username: str, password: str) -> User:  # pragma: no cover
         """Use this method to create a new user."""
         new_user = cls(username=username, password_hash=User._get_password_hash(password=password))
         session = session_var.get()
@@ -45,7 +45,7 @@ class User(Base):
         session.commit()
         return new_user
 
-    def create_session(self) -> UserSession:
+    def create_session(self) -> UserSession:  # pragma: no cover
         """Use this method to create a new session."""
         new_session = UserSession(session_id=str(uuid.uuid4()), user_id=self.id)
         session = session_var.get()
@@ -89,14 +89,14 @@ class UserSession(Base):
     user_id: int = Column(Integer, ForeignKey("users.id"), nullable=False)
     user: User = relationship("User", uselist=False)
 
-    def delete(self) -> None:
+    def delete(self) -> None:  # pragma: no cover
         """Use this method to delete a user session."""
         session = session_var.get()
         session.delete(self)
         session.commit()
 
     @staticmethod
-    def get_user_session_by_session_id(session_id: str) -> UserSession | None:
+    def get_user_session_by_session_id(session_id: str) -> UserSession | None:  # pragma: no cover
         """Use this method to get a user session with a certain id."""
         session = session_var.get()
         return session.query(UserSession).filter_by(session_id=session_id).first()

--- a/tests/users/__init__.py
+++ b/tests/users/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for 'users' REST api endpoints."""

--- a/tests/users/test_user_info_endpoint.py
+++ b/tests/users/test_user_info_endpoint.py
@@ -1,0 +1,28 @@
+"""Testing UserInfo endpoint."""
+
+
+import jwt
+
+from src.config import Config
+
+
+def test_get_user_info_endpoint_with_authorized_user_returns_200_with_correct_body(client,
+                                                                                   db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("/api/users/1", headers={"Authorization": f"Bearer {authorization_token}"})
+
+    assert result.status_code == 200
+    assert result.json == {
+        "id": 1,
+        "name": "test",
+    }
+
+
+def test_get_user_info_endpoint_with_nonexistent_topic_returns_404_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("/api/users/2", headers={"Authorization": f"Bearer {authorization_token}"})
+
+    assert result.status_code == 404
+    assert result.json == {"message": "Could not find a user with id provided."}

--- a/tests/users/test_user_list_endpoint.py
+++ b/tests/users/test_user_list_endpoint.py
@@ -1,0 +1,82 @@
+"""Testing UserList endpoint."""
+
+import jwt
+
+from src.config import Config
+
+
+def test_get_user_list_endpoint_with_no_args_returns_200_with_correct_body(client,
+                                                                           db_with_three_users):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/users", headers={"Authorization": f"Bearer {authorization_token}"})
+
+    assert result.status_code == 200
+    assert result.json == [
+        {
+            "id": 1,
+            "username": "test",
+        },
+        {
+            "id": 2,
+            "username": "test2",
+        },
+        {
+            "id": 3,
+            "username": "test3",
+        },
+    ]
+
+
+def test_get_user_list_endpoint_with_order_by_returns_200_with_correct_body(client,
+                                                                            db_with_three_users):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/users", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"order_by": "username,desc"})
+
+    assert result.status_code == 200
+    assert result.json == [
+        {
+            "id": 3,
+            "username": "test3",
+        },
+        {
+            "id": 2,
+            "username": "test2",
+        },
+        {
+            "id": 1,
+            "username": "test",
+        },
+    ]
+
+
+def test_get_user_list_endpoint_with_empty_order_by_returns_400_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/users", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"order_by": ""})
+
+    assert result.status_code == 400
+    assert result.json == {"message": "empty argument value is not allowed"}
+
+
+def test_get_user_list_endpoint_with_invalid_order_by_returns_400_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/users", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"order_by": "InvalidArgument"})
+
+    assert result.status_code == 400
+    assert result.json == {"message": "failed parsing parameters provided"}
+
+
+def test_get_user_list_endpoint_with_not_allowed_order_by_returns_400_with_correct_body(client, db_with_one_user):
+    authorization_token = jwt.encode({"user_id": 1}, Config.SECRET_KEY, algorithm="HS256")
+
+    result = client.get("api/users", headers={"Authorization": f"Bearer {authorization_token}"},
+                        query_string={"order_by": "password_hash,desc"})
+
+    assert result.status_code == 400
+    assert result.json == {"message": "provided value is not allowed"}


### PR DESCRIPTION
We want to cover our REST API part of the codebase with unit-tests.

In the scope of this task we need to cover code which is working with users in our REST API.

***

Since our REST API doesn't have registration functionality and doesn't work with cookie-sessions, the following methods are used only in ssr part of the application and we excluded them from coverage via `# pragma: no cover`:

- `User.set_password()`
- `User.create_user()`
- `User.create_session()`
- `UserSession.delete()`
- `UserSession.get_user_session_by_session_id()`