### PR TITLE
161: Fix coverage exclude rules

### DIFF
--- a/src/shared/reqparse.py
+++ b/src/shared/reqparse.py
@@ -9,7 +9,7 @@ from flask_restx import reqparse
 class RequestParser(reqparse.RequestParser):  # type: ignore
     """Customized version of flask-restx's RequestParser class."""
 
-    def __init__(self, *args: list[Any], **kwargs: Any) -> None:
+    def __init__(self, *args: list[Any], **kwargs: Any) -> None:  # pragma: no cover
         """Init method."""
         if "argument_class" not in kwargs:
             kwargs["argument_class"] = Argument
@@ -19,7 +19,7 @@ class RequestParser(reqparse.RequestParser):  # type: ignore
 class Argument(reqparse.Argument):  # type: ignore
     """Customized version of flask-restx's Argument class."""
 
-    def handle_validation_error(self, error: str | Exception, bundle_errors: bool) -> NoReturn:
+    def handle_validation_error(self, error: str | Exception, bundle_errors: bool) -> NoReturn:  # pragma: no cover
         """Reraise exception from parser function."""
         if isinstance(error, str):  # exceptions raised by flask-restx request parser itself
             abort(400, error)

--- a/src/users/utils.py
+++ b/src/users/utils.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from src.users.models import User
 
 
-def get_current_user() -> User | None:
+def get_current_user() -> User | None:  # pragma: no cover
     """Use this function to get current user."""
     user_session = None
     if session_id := request.cookies.get("session_id"):


### PR DESCRIPTION
Since we want to cover only REST API related functionality, we need to exclude some additional code related to SSR part of the application. This work is related to #129.

So in the scope of this ticket we need to exclude code in `src/shared/reqparse.py` and `src/user/utils.py`. As an outcome of this work we want to see 100% coverage, because actually all REST API code is covered at this moment.